### PR TITLE
Diverse Fixes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "lru-mem"
 description = "An LRU cache implementation bounded by memory."
-version = "0.1.3"
+version = "0.1.4"
 authors = [ "florian1345 <florian1345@gmx.de>" ]
 edition = "2021"
 documentation = "https://docs.rs/lru-mem/"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -135,7 +135,7 @@ impl<K: MemSize, V: MemSize> Entry<K, V> {
 /// ```
 /// let key_1 = 0u64;
 /// let value_1 = vec![0u8; 10];
-/// let size_1 = lru_mem::entry_size(&key_1, &value_1)
+/// let size_1 = lru_mem::entry_size(&key_1, &value_1);
 ///
 /// let key_2 = 1u64;
 /// let value_2 = vec![0u8; 1000];


### PR DESCRIPTION
Fixed `reserve` and `try_reserve` not handling failure cases correctly.
Fixed documentation of `reserve`.
Fixed requirement for `Hash` and `Eq` not being stated for `LruCache` type parameter `K`.
Implemented a way to determine the size of an entry without adding it (function `entry_size`).
Bump version to 0.1.4.