### PR TITLE
API Completion

### DIFF
--- a/src/entry.rs
+++ b/src/entry.rs
@@ -6,7 +6,8 @@ use std::ptr;
 /// Gets the memory an entry with the given key and value would occupy in an
 /// LRU cache, in bytes. This is also the function used internally, thus if the
 /// returned number of bytes fits inside the cache (as can be determined using
-/// [LruCache::current_size] and [LruCache::max_size]), it is guaranteed not to
+/// [LruCache::current_size](crate::LruCache::current_size) and
+/// [LruCache::max_size](crate::LruCache::max_size)), it is guaranteed not to
 /// eject an element.
 ///
 /// # Arguments

--- a/src/entry.rs
+++ b/src/entry.rs
@@ -1,0 +1,249 @@
+use crate::MemSize;
+
+use std::mem::{self, MaybeUninit};
+use std::ptr;
+
+/// Gets the memory an entry with the given key and value would occupy in an
+/// LRU cache, in bytes. This is also the function used internally, thus if the
+/// returned number of bytes fits inside the cache (as can be determined using
+/// [LruCache::current_size] and [LruCache::max_size]), it is guaranteed not to
+/// eject an element.
+///
+/// # Arguments
+///
+/// * `key`: A reference to the key of the entry whose size to determine.
+/// * `value`: A reference to the value of the entry whose size to determine.
+///
+/// # Example
+///
+/// ```
+/// let key_1 = 0u64;
+/// let value_1 = vec![0u8; 10];
+/// let size_1 = lru_mem::entry_size(&key_1, &value_1);
+///
+/// let key_2 = 1u64;
+/// let value_2 = vec![0u8; 1000];
+/// let size_2 = lru_mem::entry_size(&key_2, &value_2);
+///
+/// assert!(size_1 < size_2);
+/// ```
+pub fn entry_size<K: MemSize, V: MemSize>(key: &K, value: &V) -> usize {
+    let key_heap_size = key.heap_size();
+    let value_heap_size = value.heap_size();
+    let value_size = mem::size_of::<Entry<K, V>>();
+    key_heap_size + value_heap_size + value_size
+}
+
+pub(crate) struct UnhingedEntry<K, V> {
+    size: usize,
+    key: K,
+    value: V
+}
+
+impl<K: MemSize, V: MemSize> UnhingedEntry<K, V> {
+    pub(crate) fn new(key: K, value: V) -> UnhingedEntry<K, V> {
+        let size = entry_size(&key, &value);
+
+        UnhingedEntry {
+            size,
+            key,
+            value
+        }
+    }
+}
+
+impl<K, V> UnhingedEntry<K, V> {
+    pub(crate) fn size(&self) -> usize {
+        self.size
+    }
+
+    pub(crate) fn key(&self) -> &K {
+        &self.key
+    }
+
+    pub(crate) fn into_key_value(self) -> (K, V) {
+        (self.key, self.value)
+    }
+}
+
+pub(crate) struct Entry<K, V> {
+    pub(crate) size: usize,
+    pub(crate) prev: EntryPtr<K, V>,
+    pub(crate) next: EntryPtr<K, V>,
+    key: MaybeUninit<K>,
+    value: MaybeUninit<V>
+}
+
+impl<K, V> Entry<K, V> {
+
+    /// Safety: Requires key to be initialized.
+    pub(crate) unsafe fn key(&self) -> &K {
+        self.key.assume_init_ref()
+    }
+
+    /// Safety: Requires value to be initialized.
+    pub(crate) unsafe fn value(&self) -> &V {
+        self.value.assume_init_ref()
+    }
+
+    /// Safety: Requires value to be initialized.
+    pub(crate) unsafe fn value_mut(&mut self) -> &mut V {
+        self.value.assume_init_mut()
+    }
+
+    /// Safety: Requires key and value to be initialized.
+    pub(crate) unsafe fn into_key_value(self) -> (K, V) {
+        (self.key.assume_init(), self.value.assume_init())
+    }
+
+    // Safety: Requires key and value to be initialized.
+    pub(crate) unsafe fn drop(mut self) {
+        ptr::drop_in_place(self.key.as_mut_ptr());
+        ptr::drop_in_place(self.value.as_mut_ptr());
+    }
+
+    /// Safety: Key and value must be initialized.
+    pub(crate) unsafe fn unhinge(mut self) -> UnhingedEntry<K, V> {
+        self.prev.get_mut().next = self.next;
+        self.next.get_mut().prev = self.prev;
+
+        UnhingedEntry {
+            size: self.size,
+            key: self.key.assume_init(),
+            value: self.value.assume_init()
+        }
+    }
+}
+
+impl<K: Clone, V: Clone> Entry<K, V> {
+
+    /// Safety: Requires key and value to be initialized.
+    pub(crate) unsafe fn clone(&self) -> Entry<K, V> {
+        Entry {
+            size: self.size,
+            prev: self.prev,
+            next: self.next,
+            key: MaybeUninit::new(self.key().clone()),
+            value: MaybeUninit::new(self.value().clone())
+        }
+    }
+}
+
+impl<K, V> Entry<K, V> {
+    pub(crate) fn new(entry: UnhingedEntry<K, V>, prev: EntryPtr<K, V>,
+            next: EntryPtr<K, V>) -> Entry<K, V> {
+        Entry {
+            size: entry.size,
+            prev,
+            next,
+            key: MaybeUninit::new(entry.key),
+            value: MaybeUninit::new(entry.value)
+        }
+    }
+}
+
+pub(crate) struct EntryPtr<K, V> {
+    ptr: *mut Entry<K, V>
+}
+
+impl<K, V> PartialEq for EntryPtr<K, V> {
+    fn eq(&self, other: &Self) -> bool {
+        self.ptr == other.ptr
+    }
+}
+
+impl<K, V> Clone for EntryPtr<K, V> {
+    fn clone(&self) -> Self {
+        EntryPtr {
+            ptr: self.ptr
+        }
+    }
+}
+
+impl<K, V> Copy for EntryPtr<K, V> { }
+
+impl<K, V> EntryPtr<K, V> {
+
+    pub(crate) fn new(ptr: *mut Entry<K, V>) -> EntryPtr<K, V> {
+        EntryPtr { ptr }
+    }
+
+    pub(crate) fn new_seal() -> EntryPtr<K, V> {
+        let entry = Entry {
+            size: 0,
+            prev: EntryPtr {
+                ptr: ptr::null_mut()
+            },
+            next: EntryPtr {
+                ptr: ptr::null_mut()
+            },
+            key: MaybeUninit::uninit(),
+            value: MaybeUninit::uninit()
+        };
+        let mut ptr = EntryPtr {
+            ptr: Box::into_raw(Box::new(entry))
+        };
+        let ptr_clone = ptr;
+        let entry = ptr.get_mut();
+        entry.prev = ptr_clone;
+        entry.next = ptr_clone;
+
+        ptr
+    }
+
+    /// Safety: May never be dereferenced in any way (get, get_mut, move_to,
+    /// read, drop_seal).
+    pub(crate) unsafe fn null() -> EntryPtr<K, V> {
+        EntryPtr {
+            ptr: ptr::null_mut()
+        }
+    }
+
+    pub(crate) fn is_null(&self) -> bool {
+        self.ptr.is_null()
+    }
+
+    pub(crate) fn get(&self) -> &Entry<K, V> {
+        unsafe { &*self.ptr }
+    }
+
+    pub(crate) fn get_mut(&mut self) -> &mut Entry<K, V> {
+        unsafe { &mut *self.ptr }
+    }
+
+    /// Safety: Must ensure the pointer is valid for the given lifetime.
+    pub(crate) unsafe fn get_extended<'a>(self) -> &'a Entry<K, V> {
+        &*self.ptr
+    }
+
+    /// Safety: Must ensure the entry is re-inserted at the appropriate
+    /// location.
+    pub(crate) unsafe fn unhinge(self) {
+        let mut prev = self.get().prev;
+        let mut next = self.get().next;
+
+        prev.get_mut().next = next;
+        next.get_mut().prev = prev;
+    }
+
+    pub(crate) fn insert(&mut self, mut prev: EntryPtr<K, V>,
+            mut next: EntryPtr<K, V>) {
+        let self_ptr = *self;
+        let entry_mut = self.get_mut();
+
+        prev.get_mut().next = self_ptr;
+        next.get_mut().prev = self_ptr;
+        entry_mut.next = next;
+        entry_mut.prev = prev;
+    }
+
+    /// Safety: This pointer and all its copies must never be used again.
+    pub(crate) unsafe fn read(self) -> Entry<K, V> {
+        ptr::read(self.ptr)
+    }
+
+    /// Safety: This pointer and all its copies must never be used again.
+    pub(crate) unsafe fn drop_seal(self) {
+        let _ = Box::from_raw(self.ptr);
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -154,9 +154,9 @@ impl<K, V> TryInsertError<K, V> {
     ///
     /// let mut cache = LruCache::new(1024);
     /// cache.insert("apple", "sweet").unwrap();
-    /// let res = cache.try_insert("apple", "sour");
+    /// let err = cache.try_insert("apple", "sour").unwrap_err();
     ///
-    /// assert_eq!((&"apple", &"sour"), res.entry());
+    /// assert_eq!((&"apple", &"sour"), err.entry());
     /// ```
     pub fn entry(&self) -> (&K, &V) {
         match self {
@@ -176,9 +176,9 @@ impl<K, V> TryInsertError<K, V> {
     ///
     /// let mut cache = LruCache::new(1024);
     /// cache.insert("apple", "sweet").unwrap();
-    /// let res = cache.try_insert("apple", "sour");
+    /// let err = cache.try_insert("apple", "sour").unwrap_err();
     ///
-    /// assert_eq!(&"apple", res.key());
+    /// assert_eq!(&"apple", err.key());
     /// ```
     pub fn key(&self) -> &K {
         self.entry().0
@@ -194,9 +194,9 @@ impl<K, V> TryInsertError<K, V> {
     ///
     /// let mut cache = LruCache::new(1024);
     /// cache.insert("apple", "sweet").unwrap();
-    /// let res = cache.try_insert("apple", "sour");
+    /// let err = cache.try_insert("apple", "sour").unwrap_err();
     ///
-    /// assert_eq!(&"sour", res.value());
+    /// assert_eq!(&"sour", err.value());
     /// ```
     pub fn value(&self) -> &V {
         self.entry().1
@@ -212,9 +212,9 @@ impl<K, V> TryInsertError<K, V> {
     ///
     /// let mut cache = LruCache::new(1024);
     /// cache.insert("apple", "sweet").unwrap();
-    /// let res = cache.try_insert("apple", "sour");
+    /// let err = cache.try_insert("apple", "sour").unwrap_err();
     ///
-    /// assert_eq!(("apple", "sour"), res.into_entry());
+    /// assert_eq!(("apple", "sour"), err.into_entry());
     /// ```
     pub fn into_entry(self) -> (K, V) {
         match self {
@@ -234,9 +234,9 @@ impl<K, V> TryInsertError<K, V> {
     ///
     /// let mut cache = LruCache::new(1024);
     /// cache.insert("apple", "sweet").unwrap();
-    /// let res = cache.try_insert("apple", "sour");
+    /// let err = cache.try_insert("apple", "sour").unwrap_err();
     ///
-    /// assert_eq!("apple", res.into_key());
+    /// assert_eq!("apple", err.into_key());
     /// ```
     pub fn into_key(self) -> K {
         self.into_entry().0
@@ -252,9 +252,9 @@ impl<K, V> TryInsertError<K, V> {
     ///
     /// let mut cache = LruCache::new(1024);
     /// cache.insert("apple", "sweet").unwrap();
-    /// let res = cache.try_insert("apple", "sour");
+    /// let err = cache.try_insert("apple", "sour").unwrap_err();
     ///
-    /// assert_eq!("sour", res.into_value());
+    /// assert_eq!("sour", err.into_value());
     /// ```
     pub fn into_value(self) -> V {
         self.into_entry().1

--- a/src/error.rs
+++ b/src/error.rs
@@ -1,14 +1,13 @@
 use std::error::Error;
 use std::fmt::{self, Debug, Display, Formatter};
 
-/// An enumeration of the different errors that can occur while handling the
-/// [LruCache](crate::LruCache).
+/// An enumeration of the different errors that can occur when calling
+/// [LruCache::insert](crate::LruCache::insert).
 #[derive(Clone, Debug, Eq, PartialEq)]
-pub enum LruError<K, V> {
+pub enum InsertError<K, V> {
 
     /// This error is raised if the amount of memory required to store an entry
-    /// to be inserted, or after its modification, is larger than the maximum
-    /// of the cache.
+    /// to be inserted is larger than the maximum of the cache.
     EntryTooLarge {
 
         /// The key of the entry which was too large.
@@ -26,16 +25,238 @@ pub enum LruError<K, V> {
     }
 }
 
-impl<K, V> Display for LruError<K, V> {
+impl<K, V> Display for InsertError<K, V> {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         match self {
-            LruError::EntryTooLarge { .. } =>
+            InsertError::EntryTooLarge { .. } =>
                 write!(f, "entry does not fit in cache")
         }
     }
 }
 
-impl<K: Debug, V: Debug> Error for LruError<K, V> { }
+impl<K: Debug, V: Debug> Error for InsertError<K, V> { }
 
-/// Syntactic sugar for `Result<T, LruError<K, V>>`.
-pub type LruResult<T, K, V> = Result<T, LruError<K, V>>;
+/// An enumeration of the different errors that can occur when calling
+/// [LruCache](crate::LruCache::mutate).
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum MutateError<K, V> {
+
+    /// This error is raised if the memory requirement of an entry is raised
+    /// above the maximum capacity of the cache in a mutation.
+    EntryTooLarge {
+
+        /// The key of the mutated entry.
+        key: K,
+
+        /// The mutated value.
+        value: V,
+
+        /// The size requirement of the entry before its mutation in bytes.
+        old_entry_size: usize,
+
+        /// The size requirement of the entry after its mutation in bytes, if
+        /// it were in the cache.
+        new_entry_size: usize,
+
+        /// The maximum size of the cache in bytes.
+        max_size: usize
+    }
+}
+
+impl<K, V> Display for MutateError<K, V> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            MutateError::EntryTooLarge { .. } =>
+                write!(f, "modified entry does not fit in cache")
+        }
+    }
+}
+
+impl<K: Debug, V: Debug> Error for MutateError<K, V> { }
+
+/// An enumeration of the different errors that can occur when calling
+/// [LruCache](crate::LruCache::try_insert).
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub enum TryInsertError<K, V> {
+
+    /// This error is raised if the cache already contained an entry with a key
+    /// equal to the given one.
+    OccupiedEntry {
+
+        /// The key of the entry to insert.
+        key: K,
+
+        /// The value of the entry to insert.
+        value: V,
+    },
+
+    /// This error is raised if the cache cannot fit the given entry without
+    /// ejecting the LRU element.
+    WouldEjectLru {
+
+        /// The key of the entry to insert.
+        key: K,
+
+        /// The value of the entry to insert.
+        value: V,
+
+        /// The computed size requirement of the entry if it were in the cache
+        /// in bytes.
+        entry_size: usize,
+
+        /// The remaining free memory of the cache in bytes.
+        free_memory: usize
+    },
+
+    /// This error is raised if the amount of memory required to store an entry
+    /// to be inserted is larger than the maximum of the cache.
+    EntryTooLarge {
+
+        /// The key of the entry which was too large.
+        key: K,
+
+        /// The value of the entry which was too large.
+        value: V,
+
+        /// The computed size requirement of the entry if it were in the cache
+        /// in bytes.
+        entry_size: usize,
+
+        /// The maximum size of the cache in bytes.
+        max_size: usize
+    }
+}
+
+impl<K, V> Display for TryInsertError<K, V> {
+    fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
+        match self {
+            TryInsertError::OccupiedEntry { .. } =>
+                write!(f, "key already has associated entry"),
+            TryInsertError::WouldEjectLru { .. } =>
+                write!(f, "entry does not fit within remaining memory"),
+            TryInsertError::EntryTooLarge { .. } =>
+                write!(f, "entry does not fit in cache")
+        }
+    }
+}
+
+impl<K: Debug, V: Debug> Error for TryInsertError<K, V> { }
+
+impl<K, V> TryInsertError<K, V> {
+
+    /// Gets references to the key and value of the entry for which
+    /// [LruCache::try_insert](crate::LruCache::try_insert) failed.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use lru_mem::LruCache;
+    ///
+    /// let mut cache = LruCache::new(1024);
+    /// cache.insert("apple", "sweet").unwrap();
+    /// let res = cache.try_insert("apple", "sour");
+    ///
+    /// assert_eq!((&"apple", &"sour"), res.entry());
+    /// ```
+    pub fn entry(&self) -> (&K, &V) {
+        match self {
+            TryInsertError::OccupiedEntry { key, value, .. } => (key, value),
+            TryInsertError::WouldEjectLru { key, value, .. } => (key, value),
+            TryInsertError::EntryTooLarge { key, value, .. } => (key, value)
+        }
+    }
+
+    /// Gets a reference to the key of the entry for which
+    /// [LruCache::try_insert](crate::LruCache::try_insert) failed.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use lru_mem::LruCache;
+    ///
+    /// let mut cache = LruCache::new(1024);
+    /// cache.insert("apple", "sweet").unwrap();
+    /// let res = cache.try_insert("apple", "sour");
+    ///
+    /// assert_eq!(&"apple", res.key());
+    /// ```
+    pub fn key(&self) -> &K {
+        self.entry().0
+    }
+
+    /// Gets a reference to the value of the entry for which
+    /// [LruCache::try_insert](crate::LruCache::try_insert) failed.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use lru_mem::LruCache;
+    ///
+    /// let mut cache = LruCache::new(1024);
+    /// cache.insert("apple", "sweet").unwrap();
+    /// let res = cache.try_insert("apple", "sour");
+    ///
+    /// assert_eq!(&"sour", res.value());
+    /// ```
+    pub fn value(&self) -> &V {
+        self.entry().1
+    }
+
+    /// Takes ownership of the error and returns the key and value of the entry
+    /// for which [LruCache::try_insert](crate::LruCache::try_insert) failed.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use lru_mem::LruCache;
+    ///
+    /// let mut cache = LruCache::new(1024);
+    /// cache.insert("apple", "sweet").unwrap();
+    /// let res = cache.try_insert("apple", "sour");
+    ///
+    /// assert_eq!(("apple", "sour"), res.into_entry());
+    /// ```
+    pub fn into_entry(self) -> (K, V) {
+        match self {
+            TryInsertError::OccupiedEntry { key, value, .. } => (key, value),
+            TryInsertError::WouldEjectLru { key, value, .. } => (key, value),
+            TryInsertError::EntryTooLarge { key, value, .. } => (key, value)
+        }
+    }
+
+    /// Takes ownership of the error and returns the key of the entry for which
+    /// [LruCache::try_insert](crate::LruCache::try_insert) failed.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use lru_mem::LruCache;
+    ///
+    /// let mut cache = LruCache::new(1024);
+    /// cache.insert("apple", "sweet").unwrap();
+    /// let res = cache.try_insert("apple", "sour");
+    ///
+    /// assert_eq!("apple", res.into_key());
+    /// ```
+    pub fn into_key(self) -> K {
+        self.into_entry().0
+    }
+
+    /// Takes ownership of the error and returns the value of the entry for
+    /// which [LruCache::try_insert](crate::LruCache::try_insert) failed.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use lru_mem::LruCache;
+    ///
+    /// let mut cache = LruCache::new(1024);
+    /// cache.insert("apple", "sweet").unwrap();
+    /// let res = cache.try_insert("apple", "sour");
+    ///
+    /// assert_eq!("sour", res.into_value());
+    /// ```
+    pub fn into_value(self) -> V {
+        self.into_entry().1
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -96,7 +96,7 @@ use entry::{Entry, EntryPtr, UnhingedEntry};
 pub use entry::entry_size;
 pub use error::{InsertError, MutateError, TryInsertError};
 pub use iter::{Drain, IntoIter, IntoKeys, IntoValues, Iter, Keys, Values};
-pub use mem_size::MemSize;
+pub use mem_size::{HeapSize, MemSize};
 
 /// An LRU (least-recently-used) cache that stores values associated with keys.
 /// Insertion, retrieval, and removal all have average-case complexity in O(1).

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -541,7 +541,7 @@ impl<K, V, S> LruCache<K, V, S> {
     /// cache.insert("apple".to_owned(), "sweet".to_owned()).unwrap();
     /// cache.insert("lemon".to_owned(), "sour".to_owned()).unwrap();
     /// cache.insert("grapefruit".to_owned(), "bitter".to_owned()).unwrap();
-    /// let mut values = cache.into_keys().collect::<Vec<_>>();
+    /// let mut values = cache.into_values().collect::<Vec<_>>();
     ///
     /// assert_eq!(&"sweet".to_owned(), &values[0]);
     /// assert_eq!(&"sour".to_owned(), &values[1]);
@@ -1310,7 +1310,7 @@ where
     /// cache.insert("apple".to_owned(), "sweet".to_owned()).unwrap();
     /// cache.insert("lemon".to_owned(), "sour".to_owned()).unwrap();
     /// cache.insert("banana".to_owned(), "sweet".to_owned()).unwrap();
-    /// cache.retain(|_, v| &v == "sweet");
+    /// cache.retain(|_, v| v.as_str() == "sweet");
     ///
     /// assert_eq!(2, cache.len());
     /// assert!(cache.get("apple").is_some());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -485,7 +485,8 @@ impl<K, V, S> LruCache<K, V, S> {
     ///
     /// Note it is important for the drain to be dropped in order to ensure
     /// integrity of the data structure. Preventing it from being dropped, e.g.
-    /// using [mem::forget], can result in unexpected behavior of the cache.
+    /// using [mem::forget](std::mem::forget), can result in unexpected
+    /// behavior of the cache.
     ///
     /// # Example
     ///

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1310,7 +1310,7 @@ where
     /// cache.insert("apple".to_owned(), "sweet".to_owned()).unwrap();
     /// cache.insert("lemon".to_owned(), "sour".to_owned()).unwrap();
     /// cache.insert("banana".to_owned(), "sweet".to_owned()).unwrap();
-    /// cache.retain(|(_, v)| &v == "sweet");
+    /// cache.retain(|_, v| &v == "sweet");
     ///
     /// assert_eq!(2, cache.len());
     /// assert!(cache.get("apple").is_some());

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,9 +83,8 @@ use std::borrow::Borrow;
 use std::fmt::{self, Debug, Formatter};
 use std::hash::{Hash, BuildHasher};
 use std::hint;
-use std::mem::{self, MaybeUninit};
-use std::ptr;
 
+mod entry;
 mod error;
 mod iter;
 mod mem_size;
@@ -93,94 +92,11 @@ mod mem_size;
 #[cfg(test)]
 mod tests;
 
-pub use error::{LruError, LruResult};
-pub use iter::{Drain, IntoIter, Iter, Keys, Values};
+use entry::{Entry, EntryPtr, UnhingedEntry};
+pub use entry::entry_size;
+pub use error::{InsertError, MutateError, TryInsertError};
+pub use iter::{Drain, IntoIter, IntoKeys, IntoValues, Iter, Keys, Values};
 pub use mem_size::MemSize;
-
-struct Entry<K, V> {
-    size: usize,
-    prev: *mut Entry<K, V>,
-    next: *mut Entry<K, V>,
-    key: MaybeUninit<K>,
-    value: MaybeUninit<V>
-}
-
-impl<K, V> Entry<K, V> {
-    fn new_seal() -> Entry<K, V> {
-        Entry {
-            size: 0,
-            prev: ptr::null_mut(),
-            next: ptr::null_mut(),
-            key: MaybeUninit::uninit(),
-            value: MaybeUninit::uninit()
-        }
-    }
-
-    unsafe fn key(&self) -> &K {
-        self.key.assume_init_ref()
-    }
-
-    unsafe fn value(&self) -> &V {
-        self.value.assume_init_ref()
-    }
-}
-
-impl<K: Clone, V: Clone> Entry<K, V> {
-    unsafe fn clone(&self) -> Entry<K, V> {
-        Entry {
-            size: self.size,
-            prev: self.prev,
-            next: self.next,
-            key: MaybeUninit::new(self.key().clone()),
-            value: MaybeUninit::new(self.value().clone())
-        }
-    }
-}
-
-impl<K: MemSize, V: MemSize> Entry<K, V> {
-    fn new(key: K, value: V) -> Entry<K, V> {
-        let size = entry_size(&key, &value);
-
-        Entry {
-            size,
-            prev: ptr::null_mut(),
-            next: ptr::null_mut(),
-            key: MaybeUninit::new(key),
-            value: MaybeUninit::new(value)
-        }
-    }
-}
-
-/// Gets the memory an entry with the given key and value would occupy in an
-/// LRU cache, in bytes. This is also the function used internally, thus if the
-/// returned number of bytes fits inside the cache (as can be determined using
-/// [LruCache::current_size] and [LruCache::max_size]), it is guaranteed not to
-/// eject an element.
-///
-/// # Arguments
-///
-/// * `key`: A reference to the key of the entry whose size to determine.
-/// * `value`: A reference to the value of the entry whose size to determine.
-///
-/// # Example
-///
-/// ```
-/// let key_1 = 0u64;
-/// let value_1 = vec![0u8; 10];
-/// let size_1 = lru_mem::entry_size(&key_1, &value_1);
-///
-/// let key_2 = 1u64;
-/// let value_2 = vec![0u8; 1000];
-/// let size_2 = lru_mem::entry_size(&key_2, &value_2);
-///
-/// assert!(size_1 < size_2);
-/// ```
-pub fn entry_size<K: MemSize, V: MemSize>(key: &K, value: &V) -> usize {
-    let key_size = key.mem_size();
-    let value_size = value.mem_size();
-    let meta_size = mem::size_of::<Entry<(), ()>>();
-    key_size + value_size + meta_size
-}
 
 /// An LRU (least-recently-used) cache that stores values associated with keys.
 /// Insertion, retrieval, and removal all have average-case complexity in O(1).
@@ -198,6 +114,9 @@ pub fn entry_size<K: MemSize, V: MemSize>(key: &K, value: &V) -> usize {
 /// [MemSize] trait to allow for size estimation in normal usage. In addition,
 /// the key type `K` is required to implement [Hash] and [Eq] for most
 /// meaningful operations.
+///
+/// Furthermore, the hasher type `S` must implement the [BuildHasher] trait for
+/// non-trivial functionality.
 ///
 /// Mutable access is not allowed directly, since it may change the size of an
 /// entry. It must be done either by removing the element using
@@ -218,7 +137,7 @@ pub struct LruCache<K, V, S = DefaultHashBuilder> {
 
     // This system is inspired by the lru-crate: https://crates.io/crates/lru
 
-    seal: *mut Entry<K, V>,
+    seal: EntryPtr<K, V>,
     current_size: usize,
     max_size: usize,
     hash_builder: S
@@ -279,12 +198,7 @@ impl<K, V, S> LruCache<K, V, S> {
 
     fn with_table_and_hasher(max_size: usize, table: RawTable<Entry<K, V>>,
             hash_builder: S) -> LruCache<K, V, S> {
-        let seal = Box::into_raw(Box::new(Entry::new_seal()));
-
-        unsafe {
-            (*seal).next = seal;
-            (*seal).prev = seal;
-        }
+        let seal = EntryPtr::new_seal();
 
         LruCache {
             table,
@@ -343,7 +257,7 @@ impl<K, V, S> LruCache<K, V, S> {
     /// use hashbrown::hash_map::DefaultHashBuilder;
     /// use lru_mem::LruCache;
     ///
-    /// // Create an LRU with 8 KiB memory limit that can hold at least 8
+    /// // Create an LRU with 4 KiB memory limit that can hold at least 8
     /// // elements without reallocating that uses s for hashing keys.
     /// let s = DefaultHashBuilder::default();
     /// let cache: LruCache<String, String> =
@@ -441,10 +355,50 @@ impl<K, V, S> LruCache<K, V, S> {
         self.table.capacity()
     }
 
+    /// Returns a reference to the cache's [BuildHasher].
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use hashbrown::hash_map::DefaultHashBuilder;
+    /// use lru_mem::LruCache;
+    ///
+    /// let hasher = DefaultHashBuilder::default();
+    /// let cache: LruCache<String, String> =
+    ///     LruCache::with_hasher(4096, hasher);
+    /// let hasher: &DefaultHashBuilder = cache.hasher();
+    /// ```
+    pub fn hasher(&self) -> &S {
+        &self.hash_builder
+    }
+
+    /// Removes all elements from this cache.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use lru_mem::LruCache;
+    ///
+    /// let mut cache = LruCache::new(1024);
+    /// cache.insert("apple".to_owned(), "sweet".to_owned()).unwrap();
+    /// cache.insert("lemon".to_owned(), "sour".to_owned()).unwrap();
+    /// cache.clear();
+    ///
+    /// assert_eq!(None, cache.get("lemon"));
+    /// assert_eq!(0, cache.len());
+    /// assert_eq!(0, cache.current_size());
+    /// ```
+    pub fn clear(&mut self) {
+        self.table.clear();
+        self.current_size = 0;
+    }
+
     /// Creates an iterator over the entries (keys and values) contained in
     /// this cache, ordered from least- to most-recently-used. The values are
     /// not touched, i.e. the usage history is not altered in any way. That is,
     /// the semantics are as in [LruCache::peek].
+    ///
+    /// The memory requirement for any key or value may not be changed.
     ///
     /// # Example
     ///
@@ -475,6 +429,8 @@ impl<K, V, S> LruCache<K, V, S> {
     /// usage history is not altered in any way. That is, the semantics are as
     /// in [LruCache::peek].
     ///
+    /// The memory requirement for any key may not be changed.
+    ///
     /// # Example
     ///
     /// ```
@@ -501,6 +457,8 @@ impl<K, V, S> LruCache<K, V, S> {
     /// usage history is not altered in any way. That is, the semantics are as
     /// in [LruCache::peek].
     ///
+    /// The memory requirement for any value may not be changed.
+    ///
     /// # Example
     ///
     /// ```
@@ -520,6 +478,77 @@ impl<K, V, S> LruCache<K, V, S> {
     /// ```
     pub fn values(&self) -> Values<'_, K, V> {
         Values::new(self)
+    }
+
+    /// Creates an iterator that drains entries from this cache. Both key and
+    /// value of each entry are returned. The cache is cleared afterward.
+    ///
+    /// Note it is important for the drain to be dropped in order to ensure
+    /// integrity of the data structure. Preventing it from being dropped, e.g.
+    /// using [mem::forget], can result in unexpected behavior of the cache.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use lru_mem::LruCache;
+    ///
+    /// let mut cache = LruCache::new(1024);
+    /// cache.insert("apple".to_owned(), "sweet".to_owned()).unwrap();
+    /// cache.insert("lemon".to_owned(), "sour".to_owned()).unwrap();
+    /// cache.insert("grapefruit".to_owned(), "bitter".to_owned()).unwrap();
+    /// let mut vec = cache.drain().collect::<Vec<_>>();
+    ///
+    /// assert_eq!(&("apple".to_owned(), "sweet".to_owned()), &vec[0]);
+    /// assert_eq!(&("lemon".to_owned(), "sour".to_owned()), &vec[1]);
+    /// assert_eq!(&("grapefruit".to_owned(), "bitter".to_owned()), &vec[2]);
+    /// assert!(cache.is_empty());
+    /// ```
+    pub fn drain(&mut self) -> Drain<'_, K, V, S> {
+        Drain::new(self)
+    }
+
+    /// Creates an iterator that takes ownership of the cache and iterates over
+    /// its keys, ordered from least- to most-recently-used.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use lru_mem::LruCache;
+    ///
+    /// let mut cache = LruCache::new(1024);
+    /// cache.insert("apple".to_owned(), "sweet".to_owned()).unwrap();
+    /// cache.insert("lemon".to_owned(), "sour".to_owned()).unwrap();
+    /// cache.insert("grapefruit".to_owned(), "bitter".to_owned()).unwrap();
+    /// let mut keys = cache.into_keys().collect::<Vec<_>>();
+    ///
+    /// assert_eq!(&"apple".to_owned(), &keys[0]);
+    /// assert_eq!(&"lemon".to_owned(), &keys[1]);
+    /// assert_eq!(&"grapefruit".to_owned(), &keys[2]);
+    /// ```
+    pub fn into_keys(self) -> IntoKeys<K, V, S> {
+        IntoKeys::new(self)
+    }
+
+    /// Creates an iterator that takes ownership of the cache and iterates over
+    /// its values, ordered from least- to most-recently-used.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use lru_mem::LruCache;
+    ///
+    /// let mut cache = LruCache::new(1024);
+    /// cache.insert("apple".to_owned(), "sweet".to_owned()).unwrap();
+    /// cache.insert("lemon".to_owned(), "sour".to_owned()).unwrap();
+    /// cache.insert("grapefruit".to_owned(), "bitter".to_owned()).unwrap();
+    /// let mut values = cache.into_keys().collect::<Vec<_>>();
+    ///
+    /// assert_eq!(&"sweet".to_owned(), &values[0]);
+    /// assert_eq!(&"sour".to_owned(), &values[1]);
+    /// assert_eq!(&"bitter".to_owned(), &values[2]);
+    /// ```
+    pub fn into_values(self) -> IntoValues<K, V, S> {
+        IntoValues::new(self)
     }
 }
 
@@ -596,9 +625,9 @@ where
 
     #[inline]
     fn insert_into_table_with_hash(&mut self, hash: u64, entry: Entry<K, V>)
-            -> Result<*mut Entry<K, V>, Entry<K, V>> {
+            -> Result<EntryPtr<K, V>, Entry<K, V>> {
         match self.table.try_insert_no_grow(hash, entry) {
-            Ok(bucket) => Ok(bucket.as_ptr()),
+            Ok(bucket) => Ok(EntryPtr::new(bucket.as_ptr())),
             Err(entry) => Err(entry)
         }
     }
@@ -607,46 +636,36 @@ where
     /// insertion works, returns a pointer to the entry inside the table.
     /// Otherwise, returns the entry input into this function.
     fn insert_into_table(&mut self, entry: Entry<K, V>)
-            -> Result<*mut Entry<K, V>, Entry<K, V>> {
-        let key = unsafe { entry.key.assume_init_ref() };
+            -> Result<EntryPtr<K, V>, Entry<K, V>> {
+        let key = unsafe { entry.key() };
         let hash = make_insert_hash::<K, S>(&self.hash_builder, key);
 
         self.insert_into_table_with_hash(hash, entry)
     }
 
-    #[inline]
-    unsafe fn unhinge(&mut self, entry: &Entry<K, V>) {
-        let prev = entry.prev;
-        let next = entry.next;
-
-        (*prev).next = next;
-        (*next).prev = prev;
+    fn set_head(&mut self, mut entry: EntryPtr<K, V>) {
+        entry.insert(self.seal, self.seal.get().next);
     }
 
-    unsafe fn set_head(&mut self, entry: *mut Entry<K, V>) {
-        let next = (*self.seal).next;
-        (*entry).next = next;
-        (*entry).prev = self.seal;
-        (*next).prev = entry;
-        (*self.seal).next = entry;
-    }
-
-    unsafe fn touch_ptr(&mut self, entry: *mut Entry<K, V>) {
-        self.unhinge(&*entry);
+    fn touch_ptr(&mut self, entry: EntryPtr<K, V>) {
+        unsafe { entry.unhinge(); }
         self.set_head(entry);
     }
 
-    fn remove_metadata(&mut self, entry: Entry<K, V>) -> (K, V) {
-        unsafe {
-            self.unhinge(&entry);
-            self.current_size -= entry.size;
-            (entry.key.assume_init(), entry.value.assume_init())
-        }
+    /// Safety: Requires the key and value of the entry to be initialized.
+    unsafe fn remove_metadata(&mut self, entry: Entry<K, V>) -> (K, V) {
+        let entry = entry.unhinge();
+        self.current_size -= entry.size();
+
+        entry.into_key_value()
     }
 
+    /// Safety: Requires the key of the entry pointed to by the pointer to be
+    /// initialized, and the key and value of the entry located at that key in
+    /// the hash table to be initialized.
     #[inline]
-    unsafe fn remove_ptr(&mut self, entry: *mut Entry<K, V>) -> (K, V) {
-        let entry = self.remove_from_table((*entry).key()).unwrap();
+    unsafe fn remove_ptr(&mut self, entry: EntryPtr<K, V>) -> (K, V) {
+        let entry = self.remove_from_table(entry.get().key()).unwrap();
         self.remove_metadata(entry)
     }
 
@@ -659,7 +678,7 @@ where
     fn insert_untracked(&mut self, entry: Entry<K, V>) {
         let entry_ptr = self.insert_into_table(entry)
             .unwrap_or_else(|_| unsafe { hint::unreachable_unchecked() });
-        unsafe { self.set_head(entry_ptr) };
+        self.set_head(entry_ptr);
     }
 
     fn reallocate_with<F, R>(&mut self, reserve: F) -> R
@@ -667,20 +686,19 @@ where
         F: FnOnce(&mut Self) -> R
     {
         let mut entries = Vec::with_capacity(self.len());
-        let mut tail = unsafe { (*self.seal).prev };
+        let mut tail = self.seal.get().prev;
 
         while tail != self.seal {
-            entries.push(unsafe { ptr::read(tail) });
-            tail = unsafe { (*tail).prev };
+            let entry = unsafe { tail.read() };
+            tail = entry.prev;
+            entries.push(entry);
         }
 
         self.table.clear_no_drop();
         let result = reserve(self);
 
-        unsafe {
-            (*self.seal).next = self.seal;
-            (*self.seal).prev = self.seal;
-        }
+        self.seal.get_mut().next = self.seal;
+        self.seal.get_mut().prev = self.seal;
 
         for entry in entries {
             self.insert_untracked(entry);
@@ -694,8 +712,8 @@ where
             this.table.reserve(new_capacity, make_hasher(&this.hash_builder)))
     }
 
-    fn lru_ptr(&self) -> Option<*mut Entry<K, V>> {
-        let lru = unsafe { (*self.seal).prev };
+    fn lru_ptr(&self) -> Option<EntryPtr<K, V>> {
+        let lru = self.seal.get().prev;
 
         if lru == self.seal {
             None
@@ -705,8 +723,8 @@ where
         }
     }
 
-    fn mru_ptr(&self) -> Option<*mut Entry<K, V>> {
-        let mru = unsafe { (*self.seal).next };
+    fn mru_ptr(&self) -> Option<EntryPtr<K, V>> {
+        let mru = self.seal.get().next;
 
         if mru == self.seal {
             None
@@ -744,7 +762,7 @@ where
     /// This method also marks the value as most-recently-used. If you want the
     /// usage history to not be updated, use [LruCache::peek_lru] instead.
     ///
-    /// The memory requirement of the value may not be changed.
+    /// The memory requirement of the key and value may not be changed.
     ///
     /// # Example
     ///
@@ -764,7 +782,8 @@ where
         self.lru_ptr().map(|entry| {
             unsafe {
                 self.touch_ptr(entry);
-                ((*entry).key(), (*entry).value())
+                let entry = entry.get_extended();
+                (entry.key(), entry.value())
             }
         })
     }
@@ -776,7 +795,7 @@ where
     /// This method does not mark the value as most-recently-used. If you want
     /// the usage history to be updated, use [LruCache::get_lru] instead.
     ///
-    /// The memory requirement of the value may not be changed.
+    /// The memory requirement of the key and value may not be changed.
     ///
     /// # Example
     ///
@@ -794,7 +813,10 @@ where
     /// ```
     pub fn peek_lru(&self) -> Option<(&K, &V)> {
         self.lru_ptr().map(|ptr|
-            unsafe { ((*ptr).key(), (*ptr).value()) })
+            unsafe {
+                let entry = ptr.get_extended();
+                (entry.key(), entry.value())
+            })
     }
 
     /// Removes the most-recently-used value from the cache. This returns both
@@ -826,7 +848,7 @@ where
     /// the usage history is updated, since it was most-recently-used before.
     /// So, there is no need for a `get_mru` method.
     ///
-    /// The memory requirement of the value may not be changed.
+    /// The memory requirement of the key and value may not be changed.
     ///
     /// # Example
     ///
@@ -842,7 +864,10 @@ where
     /// ```
     pub fn peek_mru(&self) -> Option<(&K, &V)> {
         self.mru_ptr().map(|ptr|
-            unsafe { ((*ptr).key(), (*ptr).value()) })
+            unsafe {
+                let entry = ptr.get_extended();
+                (entry.key(), entry.value())
+            })
     }
 
     fn new_capacity(&self, additional: usize)
@@ -1032,8 +1057,51 @@ where
         Q: Eq + Hash + ?Sized
     {
         if let Some(entry) = self.get_mut_from_table(key) {
-            let entry_ptr = entry as *mut Entry<K, V>;
-            unsafe { self.touch_ptr(entry_ptr); }
+            let entry_ptr = EntryPtr::new(entry as *mut Entry<K, V>);
+            self.touch_ptr(entry_ptr);
+        }
+    }
+
+    /// Gets references to the key and value of the entry associated with the
+    /// given key. If there is no entry for that key, `None` is returned.
+    ///
+    /// This method also marks the entry as most-recently-used (see
+    /// [LruCache::touch]). If you do not want the usage history to be updated,
+    /// use [LruCache::peek_entry] instead.
+    ///
+    /// The memory requirement of the key and value may not be changed.
+    ///
+    /// # Arguments
+    ///
+    /// * `key`: The key of the entry to get.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use lru_mem::LruCache;
+    ///
+    /// let mut cache = LruCache::new(1024);
+    /// cache.insert("apple".to_owned(), "sweet".to_owned()).unwrap();
+    /// cache.insert("lemon".to_owned(), "sour".to_owned()).unwrap();
+    ///
+    /// assert_eq!(Some((&"apple".to_owned(), &"sweet".to_owned())),
+    ///     cache.get_entry("apple"));
+    /// assert_eq!(Some(("lemon".to_owned(), "sour".to_owned())),
+    ///     cache.remove_lru());
+    /// ```
+    pub fn get_entry<Q>(&mut self, key: &Q) -> Option<(&K, &V)>
+    where
+        K: Borrow<Q>,
+        Q: Eq + Hash + ?Sized
+    {
+        if let Some(entry) = self.get_mut_from_table(key) {
+            let entry_ptr = EntryPtr::new(entry as *mut Entry<K, V>);
+            self.touch_ptr(entry_ptr);
+            let entry = unsafe { entry_ptr.get_extended() };
+            Some(unsafe { (entry.key(), entry.value()) })
+        }
+        else {
+            None
         }
     }
 
@@ -1068,14 +1136,41 @@ where
         K: Borrow<Q>,
         Q: Eq + Hash + ?Sized
     {
-        if let Some(entry) = self.get_mut_from_table(key) {
-            let entry_ptr = entry as *mut Entry<K, V>;
-            unsafe { self.touch_ptr(entry_ptr); }
-            Some(unsafe { (*entry_ptr).value() })
-        }
-        else {
-            None
-        }
+        self.get_entry(key).map(|(_, v)| v)
+    }
+
+    /// Gets references to the key and value of the entry associated with the
+    /// given key. If there is no entry for that key, `None` is returned.
+    ///
+    /// This method does not mark the value as most-recently-used. If you want
+    /// the usage history to be updated, use [LruCache::get_entry] instead.
+    ///
+    /// The memory requirement of the key and value may not be changed.
+    ///
+    /// # Arguments
+    ///
+    /// * `key`: The key of the entry to peek.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use lru_mem::LruCache;
+    ///
+    /// let mut cache = LruCache::new(1024);
+    /// cache.insert("apple".to_owned(), "sweet".to_owned()).unwrap();
+    /// cache.insert("lemon".to_owned(), "sour".to_owned()).unwrap();
+    ///
+    /// assert_eq!(Some((&"apple".to_owned(), &"sweet".to_owned())),
+    ///     cache.peek_entry("apple"));
+    /// assert_eq!(Some(("apple".to_owned(), "sweet".to_owned())),
+    ///     cache.remove_lru());
+    /// ```
+    pub fn peek_entry<Q>(&self, key: &Q) -> Option<(&K, &V)>
+    where
+        K: Borrow<Q>,
+        Q: Eq + Hash + ?Sized
+    {
+        self.get_from_table(key).map(|e| unsafe { (e.key(), e.value()) })
     }
 
     /// Gets a reference to the value associated with the given key. If there
@@ -1161,7 +1256,8 @@ where
         K: Borrow<Q>,
         Q: Eq + Hash + ?Sized
     {
-        self.remove_from_table(key).map(|entry| self.remove_metadata(entry))
+        self.remove_from_table(key)
+            .map(|entry| unsafe { self.remove_metadata(entry) })
     }
 
     /// Removes and returns the value associated with the given key from this
@@ -1191,7 +1287,19 @@ where
         self.remove_entry(key).map(|(_, v)| v)
     }
 
-    /// Removes all elements from this cache.
+    /// Retains only the elements which satisfy the predicate. In other words,
+    /// removes all entries `(k, v)` such that `pred(&k, &v)` returns `false`.
+    /// The elements are visited ordered from least-recently-used to
+    /// most-recently-used.
+    ///
+    /// For all retained entries, i.e. those where `pred` returns `true`, the
+    /// memory requirement of the key and value may not be changed.
+    ///
+    /// # Arguments
+    ///
+    /// * `pred`: A function which takes as input references to the key and
+    /// value of an entry and decides whether it should remain in the map
+    /// (`true`) or not (`false`).
     ///
     /// # Example
     ///
@@ -1201,42 +1309,61 @@ where
     /// let mut cache = LruCache::new(1024);
     /// cache.insert("apple".to_owned(), "sweet".to_owned()).unwrap();
     /// cache.insert("lemon".to_owned(), "sour".to_owned()).unwrap();
-    /// cache.clear();
+    /// cache.insert("banana".to_owned(), "sweet".to_owned()).unwrap();
+    /// cache.retain(|(_, v)| &v == "sweet");
     ///
-    /// assert_eq!(None, cache.get("lemon"));
-    /// assert_eq!(0, cache.len());
-    /// assert_eq!(0, cache.current_size());
+    /// assert_eq!(2, cache.len());
+    /// assert!(cache.get("apple").is_some());
+    /// assert!(cache.get("lemon").is_none());
+    /// assert!(cache.get("banana").is_some());
     /// ```
-    pub fn clear(&mut self) {
-        self.table.clear();
-        self.current_size = 0;
-    }
+    pub fn retain<F>(&mut self, mut pred: F)
+    where
+        F: FnMut(&K, &V) -> bool
+    {
+        let mut tail = self.seal.get().prev;
 
-    /// Creates an iterator that drains entries from this cache. Both key and
-    /// value of each entry are returned. The cache is cleared afterward.
-    ///
-    /// Note it is important for the drain to be dropped in order to ensure
-    /// integrity of the data structure. Preventing it from being dropped, e.g.
-    /// using [mem::forget], can result in unexpected behavior of the cache.
-    ///
-    /// # Example
-    ///
-    /// ```
-    /// use lru_mem::LruCache;
-    ///
-    /// let mut cache = LruCache::new(1024);
-    /// cache.insert("apple".to_owned(), "sweet".to_owned()).unwrap();
-    /// cache.insert("lemon".to_owned(), "sour".to_owned()).unwrap();
-    /// cache.insert("grapefruit".to_owned(), "bitter".to_owned()).unwrap();
-    /// let mut vec = cache.drain().collect::<Vec<_>>();
-    ///
-    /// assert_eq!(&("apple".to_owned(), "sweet".to_owned()), &vec[0]);
-    /// assert_eq!(&("lemon".to_owned(), "sour".to_owned()), &vec[1]);
-    /// assert_eq!(&("grapefruit".to_owned(), "bitter".to_owned()), &vec[2]);
-    /// assert!(cache.is_empty());
-    /// ```
-    pub fn drain(&mut self) -> Drain<'_, K, V, S> {
-        Drain::new(self)
+        while tail != self.seal {
+            unsafe {
+                let entry = tail.get();
+                let key = entry.key();
+
+                if !pred(key, entry.value()) {
+                    self.remove_entry(key);
+                }
+
+                tail = entry.prev;
+            }
+        }
+    }
+}
+
+struct EntryTooLarge<K, V> {
+    key: K,
+    value: V,
+    entry_size: usize,
+    max_size: usize
+}
+
+impl<K, V> From<EntryTooLarge<K, V>> for InsertError<K, V> {
+    fn from(data: EntryTooLarge<K, V>) -> InsertError<K, V> {
+        InsertError::EntryTooLarge {
+            key: data.key,
+            value: data.value,
+            entry_size: data.entry_size,
+            max_size: data.max_size
+        }
+    }
+}
+
+impl<K, V> From<EntryTooLarge<K, V>> for TryInsertError<K, V> {
+    fn from(data: EntryTooLarge<K, V>) -> TryInsertError<K, V> {
+        TryInsertError::EntryTooLarge {
+            key: data.key,
+            value: data.value,
+            entry_size: data.entry_size,
+            max_size: data.max_size
+        }
     }
 }
 
@@ -1246,10 +1373,56 @@ where
     V: MemSize,
     S: BuildHasher
 {
+    fn prepare_insert(&mut self, key: K, value: V)
+            -> Result<UnhingedEntry<K, V>, EntryTooLarge<K, V>> {
+        let entry = UnhingedEntry::new(key, value);
+        let entry_size = entry.size();
+
+        if entry_size > self.max_size {
+            let (key, value) = entry.into_key_value();
+
+            Err(EntryTooLarge {
+                key,
+                value,
+                entry_size,
+                max_size: self.max_size
+            })
+        }
+        else {
+            Ok(entry)
+        }
+    }
+
+    fn insert_unchecked(&mut self, entry: UnhingedEntry<K, V>, hash: u64) {
+        let size = entry.size();
+        let mut entry = Entry::new(entry, self.seal, self.seal.get().next);
+
+        loop {
+            match self.insert_into_table_with_hash(hash, entry) {
+                Ok(entry_ptr) => {
+                    self.current_size += size;
+                    self.set_head(entry_ptr);
+                    return;
+                },
+                Err(returned_entry) => {
+                    entry = returned_entry;
+                    self.reallocate(self.table.capacity() * 2 + 1);
+                    
+                    // The seal pointer stays constant through reallocation, so
+                    // only entry.next has to be set.
+
+                    entry.next = self.seal.get().next;
+                }
+            }
+        }
+    }
+
     /// Inserts a new entry into this cache. This is initially the
     /// most-recently-used entry. If there was an entry with the given key
     /// before, it is removed and its value returned. Otherwise, `None` is
-    /// returned.
+    /// returned. If inserting this entry would violate the memory limit,
+    /// the least-recently-used values are ejected from the cache until it
+    /// fits.
     ///
     /// If you want to know before calling this method whether elements would
     /// be ejected, you can use [entry_size] to obtain the memory usage that
@@ -1263,8 +1436,8 @@ where
     ///
     /// # Errors
     ///
-    /// Raises an [LruError::EntryTooLarge] if the entry alone would already be
-    /// too large to fit inside the cache's size limit. That is, even if all
+    /// Raises an [InsertError::EntryTooLarge] if the entry alone would already
+    /// be too large to fit inside the cache's size limit. That is, even if all
     /// other entries were ejected, it still would not be able to be inserted.
     /// If this occurs, the entry was not inserted.
     ///
@@ -1279,46 +1452,93 @@ where
     ///
     /// assert_eq!(2, cache.len());
     /// ```
-    pub fn insert(&mut self, key: K, value: V) -> LruResult<Option<V>, K, V> {
-        let mut entry = Entry::new(key, value);
-
-        if entry.size > self.max_size {
-            let key = unsafe { entry.key.assume_init() };
-            let value = unsafe { entry.value.assume_init() };
-
-            return Err(LruError::EntryTooLarge {
-                key,
-                value,
-                entry_size: entry.size,
-                max_size: self.max_size
-            });
-        }
+    pub fn insert(&mut self, key: K, value: V)
+            -> Result<Option<V>, InsertError<K, V>> {
+        let entry = self.prepare_insert(key, value)?;
 
         // Deduplicate keys, make space
 
-        let key = unsafe { entry.key() };
+        let key = entry.key();
         let hash = make_insert_hash::<K, S>(&self.hash_builder, key);
         let result = self.table.remove_entry(hash, equivalent_key(key))
-            .map(|e| self.remove_metadata(e).1);
-        self.eject_to_target(self.max_size - entry.size);
+            .map(|e| unsafe { self.remove_metadata(e).1 });
+        self.eject_to_target(self.max_size - entry.size());
 
         // Insert entry at head of list
 
-        let size = entry.size;
+        self.insert_unchecked(entry, hash);
+        Ok(result)
+    }
 
-        loop {
-            match self.insert_into_table_with_hash(hash, entry) {
-                Ok(entry_ptr) => {
-                    self.current_size += size;
-                    unsafe { self.set_head(entry_ptr) };
-                    return Ok(result);
-                },
-                Err(returned_entry) => {
-                    entry = returned_entry;
-                    self.reallocate(self.table.capacity() * 2 + 1);
-                }
-            }
+    /// Tries to insert a new entry into this cache. This is initially the
+    /// most-recently-used entry. If there was an entry with the given key
+    /// before or it does not fit within the memory requirement, an appropriate
+    /// error is raised (see below).
+    ///
+    /// # Arguments
+    ///
+    /// * `key`: The key by which the inserted entry will be identified.
+    /// * `value`: The value to store in the inserted entry.
+    ///
+    /// # Errors
+    ///
+    /// * Raises an [TryInsertError::EntryTooLarge] if the entry alone would
+    /// already be too large to fit inside the cache's size limit.
+    /// * Otherwise, raises a [TryInsertError::WouldEjectLru] if the entry does
+    /// not fit within the remaining free memory of the cache, i.e. the
+    /// difference between [LruCache::max_size] and [LruCache::current_size].
+    /// * Otherwise, raises an [TryInsertError::OccupiedEntry] if there was
+    /// already an entry with the given key.
+    ///
+    /// If any error was raised, the entry was not inserted into the cache.
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use lru_mem::LruCache;
+    ///
+    /// let mut cache = LruCache::new(1024);
+    /// let result = cache.try_insert("apple".to_owned(), "sweet".to_owned());
+    /// assert!(result.is_ok());
+    /// let result = cache.try_insert("apple".to_owned(), "sour".to_owned());
+    /// assert!(!result.is_ok());
+    /// ```
+    pub fn try_insert(&mut self, key: K, value: V)
+            -> Result<(), TryInsertError<K, V>> {
+        let entry = self.prepare_insert(key, value)?;
+
+        // Check that the entry fits
+
+        let free_memory = self.max_size - self.current_size;
+        let entry_size = entry.size();
+
+        if entry_size > free_memory {
+            let (key, value) = entry.into_key_value();
+
+            return Err(TryInsertError::WouldEjectLru {
+                key,
+                value,
+                entry_size,
+                free_memory
+            })
         }
+
+        // Check that the entry is not occupied
+
+        let key = entry.key();
+        let hash = make_insert_hash::<K, S>(&self.hash_builder, &key);
+
+        if self.table.find(hash, equivalent_key(key)).is_some() {
+            let (key, value) = entry.into_key_value();
+
+            return Err(TryInsertError::OccupiedEntry {
+                key,
+                value
+            })
+        }
+
+        self.insert_unchecked(entry, hash);
+        Ok(())
     }
 
     /// Applies a mutating function to the value associated with the given key.
@@ -1341,10 +1561,10 @@ where
     ///
     /// # Errors
     ///
-    /// Raises an [LruError::EntryTooLarge] if the operation expanded the value
-    /// so much that the entry no longer fit inside the memory limit of the
-    /// cache. If that is the case, the entry is removed and its parts returned
-    /// in the error data.
+    /// Raises an [MutateError::EntryTooLarge] if the operation expanded the
+    /// value so much that the entry no longer fit inside the memory limit of
+    /// the cache. If that is the case, the entry is removed and its parts
+    /// returned in the error data.
     ///
     /// # Example
     ///
@@ -1360,7 +1580,7 @@ where
     /// assert_eq!(Some(&"sweet and sour".to_owned()), cache.peek("apple"));
     /// ```
     pub fn mutate<Q, R, F>(&mut self, key: &Q, op: F)
-        -> LruResult<Option<R>, K, V>
+        -> Result<Option<R>, MutateError<K, V>>
     where
         K: Borrow<Q>,
         Q: Eq + Hash + ?Sized,
@@ -1375,7 +1595,7 @@ where
 
             unsafe {
                 old_value_size = entry.value().mem_size();
-                result = op(entry.value.assume_init_mut());
+                result = op(entry.value_mut());
                 new_value_size = entry.value().mem_size();
             }
 
@@ -1389,20 +1609,22 @@ where
                     // The entry is too large after the operation; eject it and
                     // raise according error.
 
+                    let old_entry_size = entry.size;
                     let (key, value) = self.remove_entry(key).unwrap();
 
-                    return Err(LruError::EntryTooLarge {
+                    return Err(MutateError::EntryTooLarge {
                         key,
                         value,
-                        entry_size: new_entry_size,
+                        old_entry_size,
+                        new_entry_size,
                         max_size
                     });
                 }
 
                 entry.size = new_entry_size;
-                let entry_ptr = entry as *mut Entry<K, V>;
+                let entry_ptr = EntryPtr::new(entry as *mut Entry<K, V>);
                 self.current_size += diff;
-                unsafe { self.touch_ptr(entry_ptr); }
+                self.touch_ptr(entry_ptr);
                 self.eject_to_target(max_size);
             }
             else {
@@ -1410,9 +1632,9 @@ where
 
                 let diff = old_value_size - new_value_size;
                 entry.size -= diff;
-                let entry_ptr = entry as *mut Entry<K, V>;
+                let entry_ptr = EntryPtr::new(entry as *mut Entry<K, V>);
                 self.current_size -= diff;
-                unsafe { self.touch_ptr(entry_ptr); }
+                self.touch_ptr(entry_ptr);
             }
 
             Ok(Some(result))
@@ -1445,10 +1667,10 @@ where
         let mut clone = LruCache::with_capacity_and_hasher(
             max_size, capacity, hash_builder);
         clone.current_size = self.current_size;
-        let mut next = unsafe { (*self.seal).prev };
+        let mut next = self.seal.get().prev;
 
         while next != self.seal {
-            let entry = unsafe { (&*next).clone() };
+            let entry = unsafe { next.get().clone() };
             next = entry.prev;
             clone.insert_untracked(entry);
         }
@@ -1459,15 +1681,12 @@ where
 
 impl<K, V, S> Drop for LruCache<K, V, S> {
     fn drop(&mut self) {
-        for mut entry in self.table.drain() {
-            unsafe {
-                ptr::drop_in_place(entry.key.as_mut_ptr());
-                ptr::drop_in_place(entry.value.as_mut_ptr());
-            }
+        for entry in self.table.drain() {
+            unsafe { entry.drop() };
         }
 
         unsafe {
-            let _ = Box::from_raw(self.seal);
+            self.seal.drop_seal();
         }
     }
 }

--- a/src/mem_size.rs
+++ b/src/mem_size.rs
@@ -171,7 +171,7 @@ pub trait MemSize : HeapSize {
     /// a [Box] or the elements and reserved memory of a [Vec]).
     ///
     /// For [Sized] types, this is always implemented as adding [mem::size_of]
-    /// of `Self` to [MemSize::heap_size]. Non-[Sized] types must provide a
+    /// of `Self` to [HeapSize::heap_size]. Non-[Sized] types must provide a
     /// custom implementation.
     ///
     /// # Example

--- a/src/mem_size.rs
+++ b/src/mem_size.rs
@@ -41,8 +41,10 @@ use std::sync::{Mutex, RwLock};
 use std::thread::ThreadId;
 use std::time::{Duration, Instant};
 
-/// A trait for types whose total size in memory can be determined at runtime.
-/// This is required for the [LruCache](crate::LruCache) to track the size of
+/// A trait for types whose size on the heap can be determined at runtime. Note
+/// for all [Sized] types, it is sufficient to implement this trait, as a
+/// blanket implementation of [MemSize] is alread provided. The latter is
+/// required for the [LruCache](crate::LruCache) to track the size of its
 /// entries. It has implementations for most common data types and containers.
 ///
 /// Note that reference-counting smart pointers deliberately do not implement
@@ -53,11 +55,10 @@ use std::time::{Duration, Instant};
 ///
 /// For simple types which are stored completely in one memory location, such
 /// as primitive types or structs of such types, it usually suffices to
-/// implement this as a call to [mem::size_of]. The example below illustrates
-/// this.
+/// implement this as a constant 0.
 ///
 /// ```
-/// use lru_mem::MemSize;
+/// use lru_mem::HeapSize;
 /// use std::mem;
 ///
 /// struct Vector2f {
@@ -65,37 +66,32 @@ use std::time::{Duration, Instant};
 ///     y: f32
 /// }
 ///
-/// impl MemSize for Vector2f {
-///     fn mem_size(&self) -> usize {
-///         // Vector2f consists of two floats, which are stored as one value,
-///         // so there is no additional heap memory allocated for a Vector2f.
-///         // It therefore suffices to call mem::size_of.
-///         mem::size_of::<Vector2f>()
+/// impl HeapSize for Vector2f {
+///     fn heap_size(&self) -> usize {
+///         0
 ///     }
 /// }
 /// ```
 ///
 /// For more complicated types, it may be necessary to account for any
 /// referenced data that is owned by the instance. If the memory is owned by
-/// some field, which already implements `MemSize`, you can rely on that
+/// some field, which already implements `HeapSize`, you can rely on that
 /// implementation to estimate the required heap memory. See below for an
 /// example of this.
 ///
 /// ```
-/// use lru_mem::MemSize;
+/// use lru_mem::HeapSize;
 ///
 /// struct Person {
 ///     name: String,
 ///     address: String
 /// }
 ///
-/// impl MemSize for Person {
-///     fn mem_size(&self) -> usize {
+/// impl HeapSize for Person {
+///     fn heap_size(&self) -> usize {
 ///         // Both members may have allocated data, which is accounted for by
-///         // calling mem_size. Note that strange alignment inside the Person
-///         // struct may actually increase the memory requirement beyond the
-///         // one computed here, but we assume it to be compact.
-///         self.name.mem_size() + self.address.mem_size()
+///         // calling heap_size.
+///         self.name.heap_size() + self.address.heap_size()
 ///     }
 /// }
 /// ```
@@ -105,26 +101,78 @@ use std::time::{Duration, Instant};
 /// for any owned referenced data.
 ///
 /// ```ignore
-/// use lru_mem::MemSize;
+/// use lru_mem::HeapSize;
 /// use std::mem;
 ///
-/// impl MemSize for String {
-///     fn mem_size(&self) -> usize {
+/// impl HeapSize for String {
+///     fn heap_size(&self) -> usize {
 ///         // The number of bytes reserved on the heap for UTF-8 data.
-///         let heap_size = self.capacity();
-///
-///         // The number of bytes occupied by the value itself (on the stack
-///         // or in whatever data structure).
-///         let value_size = mem::size_of::<String>();
-///         heap_size + value_size
+///         self.capacity()
 ///     }
 /// }
 /// ```
-pub trait MemSize {
+pub trait HeapSize {
+
+    /// The size of the referenced data that is owned by this value, usually
+    /// allocated on the heap (such as the value of a [Box] or the elements and
+    /// reserved memory of a [Vec]).
+    ///
+    /// # Example
+    ///
+    /// ```
+    /// use lru_mem::MemSize;
+    ///
+    /// assert_eq!(0, 1u64.heap_size());
+    /// assert_eq!(12, "hello world!".to_owned().heap_size());
+    /// ```
+    fn heap_size(&self) -> usize;
+}
+
+/// A trait for types whose total size in memory can be determined at runtime.
+/// This is required for the [LruCache](crate::LruCache) to track the size of
+/// entries. It has implementations for most common data types and containers.
+///
+/// Note that reference-counting smart pointers deliberately do not implement
+/// this trait, as it is not clear whether a pointer will drop the referenced
+/// content when it is ejected from the cache.
+///
+/// # Example
+///
+/// For [Sized] types, you do not need to implement this trait. Instead,
+/// implement [HeapSize].
+///
+/// Should your type not be [Sized], you need to account for both heap and
+/// value data. Consider as an example the implementation of [HeapSize] and
+/// `MemSize` on `[T]` for any type `T` that implements `MemSize`.
+///
+/// ```ignore
+/// use lru_mem::{HeapSize, MemSize};
+/// use std::mem;
+///
+/// impl<T: MemSize> HeapSize for [T] {
+///     fn heap_size(&self) -> usize {
+///         // Take the sum of the heap sizes of all elements in this array.
+///         self.iter().map(|t| t.heap_size()).sum()
+///     }
+/// }
+/// 
+/// impl<T: MemSize> MemSize for [T] {
+///     fn mem_size(&self) -> usize {
+///         // Take the total heap size of this array AND the memory allocated
+///         // for the element values itself.
+///         self.heap_size() + mem::size_of::<T>() * self.len()
+///     }
+/// }
+/// ```
+pub trait MemSize : HeapSize {
 
     /// The total size of this value in bytes. This includes the value itself
     /// as well as all owned referenced data (such as the value on the heap of
-    /// a [Box] or the elements of a [Vec]).
+    /// a [Box] or the elements and reserved memory of a [Vec]).
+    ///
+    /// For [Sized] types, this is always implemented as adding [mem::size_of]
+    /// of `Self` to [MemSize::heap_size]. Non-[Sized] types must provide a
+    /// custom implementation.
     ///
     /// # Example
     ///
@@ -133,17 +181,23 @@ pub trait MemSize {
     /// use std::mem;
     ///
     /// assert_eq!(8, 1u64.mem_size());
-    /// assert_eq!(12 + 3 * mem::size_of::<usize>(),
+    /// assert_eq!(12 + mem::size_of::<String>(),
     ///     "hello world!".to_owned().mem_size());
     /// ```
     fn mem_size(&self) -> usize;
 }
 
+impl<T: Sized + HeapSize> MemSize for T {
+    fn mem_size(&self) -> usize {
+        mem::size_of::<T>() + self.heap_size()
+    }
+}
+
 macro_rules! basic_mem_size {
     ( $t: ty ) => {
-        impl MemSize for $t {
-            fn mem_size(&self) -> usize {
-                mem::size_of::<$t>()
+        impl HeapSize for $t {
+            fn heap_size(&self) -> usize {
+                0
             }
         }
     };
@@ -204,14 +258,14 @@ basic_mem_size!(RandomState);
 
 macro_rules! tuple_mem_size {
     ( $($ts: ident),+ ) => {
-        impl<$($ts),+> MemSize for ($($ts,)+)
+        impl<$($ts),+> HeapSize for ($($ts,)+)
         where
-            $($ts: MemSize),+
+            $($ts: HeapSize),+
         {
-            fn mem_size(&self) -> usize {
+            fn heap_size(&self) -> usize {
                 #[allow(non_snake_case)]
                 let ($($ts,)+) = self;
-                0 $(+ $ts.mem_size())+
+                0 $(+ $ts.heap_size())+
             }
         }
     };
@@ -228,97 +282,99 @@ tuple_mem_size!(A, B, C, D, E, F, G, H);
 tuple_mem_size!(A, B, C, D, E, F, G, H, I);
 tuple_mem_size!(A, B, C, D, E, F, G, H, I, J);
 
-impl<T> MemSize for Wrapping<T> {
-    fn mem_size(&self) -> usize {
-        mem::size_of::<Wrapping<T>>()
+impl<T: MemSize> HeapSize for Wrapping<T> {
+    fn heap_size(&self) -> usize {
+        self.0.heap_size()
     }
 }
 
-fn sum_size<'a, T: MemSize + 'a>(iter: impl Iterator<Item = &'a T>) -> usize {
-    iter.map(|t| t.mem_size()).sum()
+fn sum_heap_size<'a, T, I>(iter: I) -> usize
+where
+    T: MemSize + 'a,
+    I: IntoIterator<Item = &'a T>
+{
+    iter.into_iter().map(|t| t.heap_size()).sum()
+}
+
+impl<T: MemSize> HeapSize for [T] {
+    fn heap_size(&self) -> usize {
+        sum_heap_size(self)
+    }
 }
 
 impl<T: MemSize> MemSize for [T] {
     fn mem_size(&self) -> usize {
-        sum_size(self.iter())
+        self.heap_size() + mem::size_of::<T>() * self.len()
     }
 }
 
-impl<T: MemSize, const N: usize> MemSize for [T; N] {
-    fn mem_size(&self) -> usize {
-        (&self[..]).mem_size()
+impl<T: MemSize, const N: usize> HeapSize for [T; N] {
+    fn heap_size(&self) -> usize {
+        (&self[..]).heap_size()
     }
 }
 
-impl<T: MemSize> MemSize for Vec<T> {
-    fn mem_size(&self) -> usize {
-        let element_size = self.as_slice().mem_size();
-        let excess_size = (self.capacity() - self.len()) * mem::size_of::<T>();
-        let value_size = mem::size_of::<Vec<T>>();
-
-        element_size + excess_size + value_size
+impl<T: MemSize> HeapSize for Vec<T> {
+    fn heap_size(&self) -> usize {
+        let element_heap_size = self.as_slice().heap_size();
+        let own_heap_size = self.capacity() * mem::size_of::<T>();
+        element_heap_size + own_heap_size
     }
 }
 
-impl<K: MemSize, V: MemSize, S: MemSize> MemSize for HashMap<K, V, S> {
-    fn mem_size(&self) -> usize {
-        let hasher_heap_size = self.hasher().mem_size() - mem::size_of::<S>();
-        let element_size = self.iter()
-            .map(|(k, v)| k.mem_size() + v.mem_size())
+impl<K: MemSize, V: MemSize, S: MemSize> HeapSize for HashMap<K, V, S> {
+    fn heap_size(&self) -> usize {
+        let hasher_heap_size = self.hasher().heap_size();
+        let element_heap_size = self.iter()
+            .map(|(k, v)| k.heap_size() + v.heap_size())
             .sum::<usize>();
-        let entry_value_size = mem::size_of::<K>() + mem::size_of::<V>();
-        let excess_size = (self.capacity() - self.len()) * entry_value_size;
-        let value_size = mem::size_of::<HashMap<K, V, S>>();
+        let key_value_size = mem::size_of::<K>() + mem::size_of::<V>();
+        let own_heap_size = self.capacity() * key_value_size;
 
-        element_size + excess_size + value_size + hasher_heap_size
+        hasher_heap_size + element_heap_size + own_heap_size
     }
 }
 
-impl<T: MemSize, S: MemSize> MemSize for HashSet<T, S> {
-    fn mem_size(&self) -> usize {
-        let hasher_heap_size = self.hasher().mem_size() - mem::size_of::<S>();
-        let element_size = sum_size(self.iter());
-        let excess_size = (self.capacity() - self.len()) * mem::size_of::<T>();
-        let value_size = mem::size_of::<HashSet<T, S>>();
+impl<T: MemSize, S: MemSize> HeapSize for HashSet<T, S> {
+    fn heap_size(&self) -> usize {
+        let hasher_heap_size = self.hasher().heap_size();
+        let element_heap_size = sum_heap_size(self);
+        let own_heap_size = self.capacity() * mem::size_of::<T>();
 
-        element_size + excess_size + value_size + hasher_heap_size
+        hasher_heap_size + element_heap_size + own_heap_size
     }
 }
 
-impl<T: MemSize> MemSize for BinaryHeap<T> {
-    fn mem_size(&self) -> usize {
-        let element_size = sum_size(self.iter());
-        let excess_size = (self.capacity() - self.len()) * mem::size_of::<T>();
-        let value_size = mem::size_of::<Vec<T>>();
+impl<T: MemSize> HeapSize for BinaryHeap<T> {
+    fn heap_size(&self) -> usize {
+        let element_heap_size = sum_heap_size(self.iter());
+        let own_heap_size = self.capacity() * mem::size_of::<T>();
 
-        element_size + excess_size + value_size
+        element_heap_size + own_heap_size
     }
 }
 
-impl<T: MemSize> MemSize for Box<T> {
-    fn mem_size(&self) -> usize {
-        let heap_size = self.as_ref().mem_size();
-        let value_size = mem::size_of::<Box<T>>();
-
-        heap_size + value_size
+impl<T: MemSize> HeapSize for Box<T> {
+    fn heap_size(&self) -> usize {
+        self.as_ref().mem_size()
     }
 }
 
-impl<T: MemSize> MemSize for Mutex<T> {
-    fn mem_size(&self) -> usize {
-        let heap_size = self.lock().unwrap().mem_size();
-        let self_size = mem::size_of::<Mutex<T>>();
-
-        heap_size + self_size
+impl<T: MemSize> HeapSize for Mutex<T> {
+    fn heap_size(&self) -> usize {
+        self.lock().unwrap().mem_size()
     }
 }
 
-impl<T: MemSize> MemSize for RwLock<T> {
-    fn mem_size(&self) -> usize {
-        let heap_size = self.read().unwrap().mem_size();
-        let self_size = mem::size_of::<RwLock<T>>();
+impl<T: MemSize> HeapSize for RwLock<T> {
+    fn heap_size(&self) -> usize {
+        self.read().unwrap().mem_size()
+    }
+}
 
-        heap_size + self_size
+impl HeapSize for str {
+    fn heap_size(&self) -> usize {
+        0
     }
 }
 
@@ -328,9 +384,15 @@ impl MemSize for str {
     }
 }
 
-impl MemSize for String {
-    fn mem_size(&self) -> usize {
-        self.capacity() + mem::size_of::<String>()
+impl HeapSize for String {
+    fn heap_size(&self) -> usize {
+        self.capacity()
+    }
+}
+
+impl HeapSize for CStr {
+    fn heap_size(&self) -> usize {
+        0
     }
 }
 
@@ -340,9 +402,15 @@ impl MemSize for CStr {
     }
 }
 
-impl MemSize for CString {
-    fn mem_size(&self) -> usize {
-        self.as_bytes_with_nul().len() + mem::size_of::<CString>()
+impl HeapSize for CString {
+    fn heap_size(&self) -> usize {
+        self.as_bytes_with_nul().len()
+    }
+}
+
+impl HeapSize for OsStr {
+    fn heap_size(&self) -> usize {
+        0
     }
 }
 
@@ -352,105 +420,99 @@ impl MemSize for OsStr {
     }
 }
 
-impl MemSize for OsString {
-    fn mem_size(&self) -> usize {
-        self.capacity() + mem::size_of::<OsString>()
+impl HeapSize for OsString {
+    fn heap_size(&self) -> usize {
+        self.capacity()
     }
 }
 
-impl<T: ?Sized> MemSize for &T {
-    fn mem_size(&self) -> usize {
-        mem::size_of::<&T>()
-    }
-}
-
-impl<T: ?Sized> MemSize for &mut T {
-    fn mem_size(&self) -> usize {
-        mem::size_of::<&mut T>()
-    }
-}
-
-impl<T: MemSize> MemSize for Option<T> {
-    fn mem_size(&self) -> usize {
-        let value_size = mem::size_of::<Option<T>>();
-
-        match self {
-            Some(v) => v.mem_size() - mem::size_of::<T>() + value_size,
-            None => value_size
-        }
-    }
-}
-
-impl<V: MemSize, E: MemSize> MemSize for Result<V, E> {
-    fn mem_size(&self) -> usize {
-        let value_size = mem::size_of::<Result<V, E>>();
-
-        match self {
-            Ok(v) => v.mem_size() - mem::size_of::<V>() + value_size,
-            Err(e) => e.mem_size() - mem::size_of::<E>() + value_size
-        }
-    }
-}
-
-impl<T> MemSize for PhantomData<T> {
-    fn mem_size(&self) -> usize {
+impl<T: ?Sized> HeapSize for &T {
+    fn heap_size(&self) -> usize {
         0
     }
 }
 
-impl MemSize for IpAddr {
-    fn mem_size(&self) -> usize {
-        let value_size = mem::size_of::<IpAddr>();
+impl<T: ?Sized> HeapSize for &mut T {
+    fn heap_size(&self) -> usize {
+        0
+    }
+}
 
+impl<T: MemSize> HeapSize for Option<T> {
+    fn heap_size(&self) -> usize {
         match self {
-            IpAddr::V4(v4) =>
-                v4.mem_size() - mem::size_of::<Ipv4Addr>() + value_size,
-            IpAddr::V6(v6) =>
-                v6.mem_size() - mem::size_of::<Ipv6Addr>() + value_size
+            Some(v) => v.heap_size(),
+            None => 0
         }
     }
 }
 
-impl MemSize for SocketAddr {
-    fn mem_size(&self) -> usize {
-        let value_size = mem::size_of::<SocketAddr>();
-
+impl<V: MemSize, E: MemSize> HeapSize for Result<V, E> {
+    fn heap_size(&self) -> usize {
         match self {
-            SocketAddr::V4(v4) =>
-                v4.mem_size() - mem::size_of::<SocketAddrV4>() + value_size,
-            SocketAddr::V6(v6) =>
-                v6.mem_size() - mem::size_of::<SocketAddrV6>() + value_size
+            Ok(v) => v.heap_size(),
+            Err(e) => e.heap_size()
         }
     }
 }
 
-impl<I: MemSize> MemSize for Range<I> {
-    fn mem_size(&self) -> usize {
-        self.start.mem_size() + self.end.mem_size()
+impl<T> HeapSize for PhantomData<T> {
+    fn heap_size(&self) -> usize {
+        0
     }
 }
 
-impl<I: MemSize> MemSize for RangeFrom<I> {
-    fn mem_size(&self) -> usize {
-        self.start.mem_size()
+impl HeapSize for IpAddr {
+    fn heap_size(&self) -> usize {
+        match self {
+            IpAddr::V4(v4) => v4.heap_size(),
+            IpAddr::V6(v6) => v6.heap_size()
+        }
     }
 }
 
-impl<I: MemSize> MemSize for RangeTo<I> {
-    fn mem_size(&self) -> usize {
-        self.end.mem_size()
+impl HeapSize for SocketAddr {
+    fn heap_size(&self) -> usize {
+        match self {
+            SocketAddr::V4(v4) => v4.heap_size(),
+            SocketAddr::V6(v6) => v6.heap_size()
+        }
     }
 }
 
-impl<I: MemSize> MemSize for RangeInclusive<I> {
-    fn mem_size(&self) -> usize {
-        self.start().mem_size() + self.end().mem_size()
+impl<I: MemSize> HeapSize for Range<I> {
+    fn heap_size(&self) -> usize {
+        self.start.heap_size() + self.end.heap_size()
     }
 }
 
-impl<I: MemSize> MemSize for RangeToInclusive<I> {
-    fn mem_size(&self) -> usize {
-        self.end.mem_size()
+impl<I: MemSize> HeapSize for RangeFrom<I> {
+    fn heap_size(&self) -> usize {
+        self.start.heap_size()
+    }
+}
+
+impl<I: MemSize> HeapSize for RangeTo<I> {
+    fn heap_size(&self) -> usize {
+        self.end.heap_size()
+    }
+}
+
+impl<I: MemSize> HeapSize for RangeInclusive<I> {
+    fn heap_size(&self) -> usize {
+        self.start().heap_size() + self.end().heap_size()
+    }
+}
+
+impl<I: MemSize> HeapSize for RangeToInclusive<I> {
+    fn heap_size(&self) -> usize {
+        self.end.heap_size()
+    }
+}
+
+impl HeapSize for Path {
+    fn heap_size(&self) -> usize {
+        0
     }
 }
 
@@ -460,8 +522,8 @@ impl MemSize for Path {
     }
 }
 
-impl MemSize for PathBuf {
-    fn mem_size(&self) -> usize {
-        self.capacity() + mem::size_of::<PathBuf>()
+impl HeapSize for PathBuf {
+    fn heap_size(&self) -> usize {
+        self.as_path().mem_size()
     }
 }

--- a/src/mem_size.rs
+++ b/src/mem_size.rs
@@ -120,7 +120,7 @@ pub trait HeapSize {
     /// # Example
     ///
     /// ```
-    /// use lru_mem::MemSize;
+    /// use lru_mem::HeapSize;
     ///
     /// assert_eq!(0, 1u64.heap_size());
     /// assert_eq!(12, "hello world!".to_owned().heap_size());


### PR DESCRIPTION
Completed API to support everything the standard HashMap can (within reason).
This includes:

- try_insert
- retain
- get_entry/peek_entry for get_key_value
- into_keys/into_values
- hasher

Internal reorganization to simplify code and better document safety conditions.
Various minor documentation improvements.
Split error types for different situations.