### PR TITLE
Rework benchmarks to reduce measuring setup/repair code

### DIFF
--- a/benches/bench/alloc.rs
+++ b/benches/bench/alloc.rs
@@ -2,20 +2,15 @@ use criterion::Criterion;
 
 use lru_mem::LruCache;
 
-use rand::rngs::ThreadRng;
-
-fn run_alloc_benchmark(cache: &mut LruCache<u64, String>, _: &[u64],
-        _: &mut ThreadRng) {
-    cache.shrink_to_fit();
-    cache.reserve(cache.capacity());
-}
+use crate::bencher_extensions::CacheBenchmarkGroup;
 
 pub(crate) fn alloc_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("alloc");
     group.sample_size(100).measurement_time(crate::BENCH_DURATION);
 
     for &size in crate::LINEAR_TIME_SIZES {
-        crate::bench_cache_function(
-            &mut group, size, run_alloc_benchmark);
+        group.bench_with_reset_cache(&crate::get_id(size), |cache| {
+            cache.reserve(cache.capacity());
+        }, LruCache::shrink_to_fit, size);
     }
 }

--- a/benches/bench/bencher_extensions.rs
+++ b/benches/bench/bencher_extensions.rs
@@ -1,0 +1,222 @@
+use std::iter::{self, Empty, Once};
+use std::time::{Duration, Instant};
+use std::vec::IntoIter as VecIntoIter;
+
+use criterion::BenchmarkGroup;
+use criterion::measurement::WallTime;
+use rand::Rng;
+
+use lru_mem::LruCache;
+
+pub(crate) trait KeysToRestore {
+    type KeyIter: Iterator<Item = String>;
+
+    fn keys(self) -> Self::KeyIter;
+}
+
+impl KeysToRestore for () {
+    type KeyIter = Empty<String>;
+
+    fn keys(self) -> Empty<String> {
+        iter::empty()
+    }
+}
+
+impl KeysToRestore for String {
+    type KeyIter = Once<String>;
+
+    fn keys(self) -> Once<String> {
+        iter::once(self)
+    }
+}
+
+impl KeysToRestore for Vec<String> {
+    type KeyIter = VecIntoIter<String>;
+
+    fn keys(self) -> VecIntoIter<String> {
+        self.into_iter()
+    }
+}
+
+/// A trait with cache-related extensions for [BenchmarkGroup].
+pub(crate) trait CacheBenchmarkGroup {
+
+    /// Benchmarks the given `routine`, which is supplied with a reset
+    /// `LruCache` with `size` elements on each iteration. After each iteration,
+    /// the given `reset` function is called to reset the cache in a use-case
+    /// specific manner. This prevents redundant cleanup steps for certain
+    /// benchmarks.
+    fn bench_with_reset_cache<O, Rou, Res>(&mut self, id: &str, routine: Rou,
+        reset: Res, size: usize)
+    where
+        Rou: FnMut(&mut LruCache<String, String>) -> O,
+        Res: FnMut(&mut LruCache<String, String>);
+
+    /// Benchmarks the given `routine`, which is supplied with a `LruCache` of
+    /// with `size` elements on each iteration. As a second argument, a slice of
+    /// all initial keys is provided. The cache is not repaired in any way after
+    /// an iteration, so it is the routine's responsibility no to change the key
+    /// set.
+    fn bench_with_cache<O, R>(&mut self, id: &str, routine: R, size: usize)
+    where
+        R: FnMut(&mut LruCache<String, String>, &[String]) -> O;
+
+    /// Benchmarks the given `routine`, which is supplied with a mutable
+    /// reference to the same `LruCache` on each iteration. Initially, the cache
+    /// is filled to the given `size`. After each iteration, every removed key,
+    /// as indicated by the [KeysToRestore] return value of the routine, is
+    /// restored. As a second argument, the routine gets a slice of all keys.
+    fn bench_with_refilled_cache<O, R>(&mut self, id: &str, routine: R,
+        size: usize)
+    where
+        O: KeysToRestore,
+        R: FnMut(&mut LruCache<String, String>, &[String]) -> O;
+
+    /// Benchmarks the given `routine`, which is supplied with a mutable
+    /// reference to the same `LruCache` on each iteration. Should the size of
+    /// the cache be greater than `max_size` after any iteration, it will be
+    /// depleted to `min_size` elements before the next iteration. The initial
+    /// size of the cache is `min_size`.
+    fn bench_with_depleted_cache<O, R>(&mut self, id: &str, routine: R,
+        min_size: usize, max_size: usize)
+    where
+        R: FnMut(&mut LruCache<String, String>) -> O;
+}
+
+fn gen_key(rng: &mut impl Rng) -> String {
+    let num = rng.gen::<u64>();
+    format!("{:016x}", num)
+}
+
+fn gen_value() -> String {
+    const VALUE_LEN: usize = 16;
+
+    let mut bytes = vec![b'0'; VALUE_LEN];
+    bytes.shrink_to_fit();
+    String::from_utf8(bytes).unwrap()
+}
+
+fn fill_to_size(cache: &mut LruCache<String, String>, size: usize) {
+    let mut rng = rand::thread_rng();
+
+    while cache.len() < size {
+        cache.insert(gen_key(&mut rng), gen_value()).unwrap();
+    }
+}
+
+fn deplete_to_size(cache: &mut LruCache<String, String>, size: usize) {
+    let mut rng = rand::thread_rng();
+    let keys = cache.keys().cloned().collect::<Vec<_>>();
+
+    while cache.len() > size {
+        let key_index = rng.gen_range(0..keys.len());
+        cache.remove(&keys[key_index]);
+    }
+}
+
+fn restore_keys<K>(cache: &mut LruCache<String, String>, keys_to_restore: K)
+where
+    K: KeysToRestore
+{
+    for key in keys_to_restore.keys() {
+        cache.insert(key, gen_value()).unwrap();
+    }
+}
+
+impl<'a> CacheBenchmarkGroup for BenchmarkGroup<'a, WallTime> {
+
+    fn bench_with_reset_cache<O, Rou, Res>(&mut self, id: &str,
+        mut routine: Rou, mut reset: Res, size: usize)
+    where
+        Rou: FnMut(&mut LruCache<String, String>) -> O,
+        Res: FnMut(&mut LruCache<String, String>)
+    {
+        let mut cache = LruCache::with_capacity(usize::MAX, size);
+
+        self.bench_function(id, |group| group.iter_custom(|iter_count| {
+            let mut total = Duration::ZERO;
+
+            for _ in 0..iter_count {
+                reset(&mut cache);
+                fill_to_size(&mut cache, size);
+
+                let start = Instant::now();
+                routine(&mut cache);
+                total += start.elapsed();
+            }
+
+            total
+        }));
+    }
+
+    fn bench_with_cache<O, R>(&mut self, id: &str, mut routine: R, size: usize)
+    where
+        R: FnMut(&mut LruCache<String, String>, &[String]) -> O
+    {
+        let mut cache = LruCache::with_capacity(usize::MAX, size);
+        fill_to_size(&mut cache, size);
+        let keys = cache.keys().cloned().collect::<Vec<_>>();
+
+        self.bench_function(id, |group| group.iter(|| routine(&mut cache, &keys)));
+    }
+
+    fn bench_with_refilled_cache<O, R>(&mut self, id: &str, mut routine: R,
+        size: usize)
+    where
+        O: KeysToRestore,
+        R: FnMut(&mut LruCache<String, String>, &[String]) -> O
+    {
+        let mut cache = LruCache::with_capacity(usize::MAX, size);
+        fill_to_size(&mut cache, size);
+        let keys = cache.keys().cloned().collect::<Vec<_>>();
+
+        self.bench_function(id, |bencher| bencher.iter_custom(|iter_count| {
+            let mut completed = 0;
+            let mut total = Duration::ZERO;
+
+            loop {
+                let before = Instant::now();
+                let keys_to_restore = routine(&mut cache, &keys);
+                total += before.elapsed();
+
+                restore_keys(&mut cache, keys_to_restore);
+                completed += 1;
+
+                if completed >= iter_count {
+                    return total;
+                }
+            }
+        }));
+    }
+
+    fn bench_with_depleted_cache<O, R>(&mut self, id: &str, mut routine: R,
+        min_size: usize, max_size: usize)
+    where
+        R: FnMut(&mut LruCache<String, String>) -> O
+    {
+        let mut cache = LruCache::with_capacity(usize::MAX, max_size);
+        fill_to_size(&mut cache, min_size);
+
+        self.bench_function(id, |bencher| bencher.iter_custom(|iter_count| {
+            let mut completed = 0;
+            let mut total = Duration::ZERO;
+            let mut last_depletion = Instant::now();
+
+            loop {
+                routine(&mut cache);
+
+                completed += 1;
+
+                if completed >= iter_count {
+                    return total + last_depletion.elapsed();
+                }
+
+                if cache.len() > max_size {
+                    total += last_depletion.elapsed();
+                    deplete_to_size(&mut cache, min_size);
+                    last_depletion = Instant::now();
+                }
+            }
+        }));
+    }
+}

--- a/benches/bench/clone.rs
+++ b/benches/bench/clone.rs
@@ -1,20 +1,14 @@
-use criterion::Criterion;
+use criterion::{black_box, Criterion};
 
-use lru_mem::LruCache;
-
-use rand::rngs::ThreadRng;
-
-fn run_clone_benchmark(cache: &mut LruCache<u64, String>, _: &[u64],
-        _: &mut ThreadRng) {
-    criterion::black_box(cache.clone());
-}
+use crate::bencher_extensions::CacheBenchmarkGroup;
 
 pub(crate) fn clone_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("clone");
     group.sample_size(100).measurement_time(crate::BENCH_DURATION);
 
     for &size in crate::LINEAR_TIME_SIZES {
-        crate::bench_cache_function(
-            &mut group, size, run_clone_benchmark);
+        group.bench_with_cache(&crate::get_id(size), |cache, _| {
+            black_box(cache.clone());
+        }, size);
     }
 }

--- a/benches/bench/drain.rs
+++ b/benches/bench/drain.rs
@@ -1,22 +1,16 @@
-use criterion::Criterion;
+use criterion::{black_box, Criterion};
 
-use lru_mem::LruCache;
-
-use rand::rngs::ThreadRng;
-
-fn run_drain_benchmark(cache: &mut LruCache<u64, String>, _: &[u64],
-        _: &mut ThreadRng) {
-    for entry in cache.drain() {
-        criterion::black_box(entry);
-    }
-}
+use crate::bencher_extensions::CacheBenchmarkGroup;
 
 pub(crate) fn drain_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("drain");
     group.sample_size(100).measurement_time(crate::BENCH_DURATION);
 
     for &size in crate::LINEAR_TIME_SIZES {
-        crate::bench_cache_function_with_refill(
-            &mut group, size, run_drain_benchmark);
+        group.bench_with_reset_cache(&crate::get_id(size), |cache| {
+            for entry in cache.drain() {
+                black_box(entry);
+            }
+        }, |_| { }, size);
     }
 }

--- a/benches/bench/get.rs
+++ b/benches/bench/get.rs
@@ -1,23 +1,19 @@
 use criterion::Criterion;
-
-use lru_mem::LruCache;
-
 use rand::Rng;
-use rand::rngs::ThreadRng;
 
-fn run_get_benchmark(cache: &mut LruCache<u64, String>, keys: &[u64],
-        _: &mut ThreadRng) {
-    let mut rng = rand::thread_rng();
-    let get_index = rng.gen_range(0..keys.len());
-    cache.get(&keys[get_index]);
-}
+use crate::bencher_extensions::CacheBenchmarkGroup;
 
 pub(crate) fn get_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("get");
     group.sample_size(100).measurement_time(crate::BENCH_DURATION);
+    let mut rng = rand::thread_rng();
 
     for &size in crate::CONSTANT_TIME_SIZES {
-        crate::bench_cache_function(
-            &mut group, size, run_get_benchmark);
+        let id = crate::get_id(size);
+
+        group.bench_with_cache(&id, |cache, keys| {
+            let key_index = rng.gen_range(0..keys.len());
+            cache.get(&keys[key_index]);
+        }, size);
     }
 }

--- a/benches/bench/heap_size.rs
+++ b/benches/bench/heap_size.rs
@@ -1,7 +1,10 @@
-use criterion::{black_box, Criterion};
-use lru_mem::HeapSize;
 use std::iter;
-use crate::get_id_with_suffixes;
+
+use criterion::{black_box, Criterion};
+
+use lru_mem::HeapSize;
+
+use crate::get_id;
 
 fn heap_size_benchmark_with<T, F>(make_value: F, sizes: &[usize], group_name: &str,
     c: &mut Criterion)
@@ -14,7 +17,7 @@ where
 
     for &size in sizes {
         let value = iter::repeat_with(&make_value).take(size).collect::<Vec<_>>();
-        let id = get_id_with_suffixes(size, "", "K", "M", "G");
+        let id = get_id(size);
         group.bench_function(id, |b| b.iter(|| {
             let heap_size = value.heap_size();
             black_box(heap_size);

--- a/benches/bench/insert.rs
+++ b/benches/bench/insert.rs
@@ -1,24 +1,18 @@
 use criterion::Criterion;
 
-use lru_mem::LruCache;
-
-use rand::Rng;
-use rand::rngs::ThreadRng;
-
-fn run_insert_benchmark(cache: &mut LruCache<u64, String>, _: &[u64],
-        _: &mut ThreadRng) {
-    let mut rng = rand::thread_rng();
-    let key = rng.gen();
-    let value = crate::value();
-    cache.insert(key, value).unwrap();
-}
+use crate::bencher_extensions::CacheBenchmarkGroup;
 
 pub(crate) fn insert_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("insert");
     group.sample_size(100).measurement_time(crate::BENCH_DURATION);
 
     for &size in crate::CONSTANT_TIME_SIZES {
-        crate::bench_cache_function(
-            &mut group, size, run_insert_benchmark);
+        let id = crate::get_id(size);
+        let mut key_idx: u32 = 0;
+
+        group.bench_with_depleted_cache(&id, |cache| {
+            cache.insert(format!("{:08x}", key_idx), String::new()).unwrap();
+            key_idx += 1;
+        }, size * 7 / 8, size);
     }
 }

--- a/benches/bench/iter.rs
+++ b/benches/bench/iter.rs
@@ -1,22 +1,16 @@
 use criterion::Criterion;
 
-use lru_mem::LruCache;
-
-use rand::rngs::ThreadRng;
-
-fn run_iter_benchmark(cache: &mut LruCache<u64, String>, _: &[u64],
-        _: &mut ThreadRng) {
-    for entry in cache.iter() {
-        criterion::black_box(entry);
-    }
-}
+use crate::bencher_extensions::CacheBenchmarkGroup;
 
 pub(crate) fn iter_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("iter");
     group.sample_size(100).measurement_time(crate::BENCH_DURATION);
 
     for &size in crate::LINEAR_TIME_SIZES {
-        crate::bench_cache_function(
-            &mut group, size, run_iter_benchmark);
+        group.bench_with_cache(&crate::get_id(size), |cache, _| {
+            for entry in cache.iter() {
+                criterion::black_box(entry);
+            }
+        }, size);
     }
 }

--- a/benches/bench/main.rs
+++ b/benches/bench/main.rs
@@ -1,11 +1,4 @@
 use std::time::Duration;
-use criterion::BenchmarkGroup;
-use criterion::measurement::WallTime;
-
-use lru_mem::LruCache;
-
-use rand::Rng;
-use rand::rngs::ThreadRng;
 
 mod alloc;
 mod clone;
@@ -17,102 +10,39 @@ mod iter;
 mod peek;
 mod remove;
 mod retain;
-
-const VALUE_LEN: usize = 100;
-
-fn value() -> String {
-    let mut bytes = vec![b'0'; VALUE_LEN];
-    bytes.shrink_to_fit();
-    unsafe { String::from_utf8_unchecked(bytes) }
-}
+mod bencher_extensions;
 
 const KIBI: usize = 1024;
 const MEBI: usize = KIBI * KIBI;
 const GIBI: usize = KIBI * MEBI;
 
-pub(crate) fn get_id_with_suffixes(size: usize, one_suffix: &str, kibi_suffix: &str,
-        mebi_suffix: &str, gibi_suffix: &str) -> String {
+pub(crate) fn get_id(size: usize) -> String {
     if size >= GIBI {
-        format!("{}{}", size / GIBI, gibi_suffix)
+        format!("{}G", size / GIBI)
     }
     else if size >= MEBI {
-        format!("{}{}", size / MEBI, mebi_suffix)
+        format!("{}M", size / MEBI)
     }
     else if size >= KIBI {
-        format!("{}{}", size / KIBI, kibi_suffix)
+        format!("{}K", size / KIBI)
     }
     else {
-        format!("{}{}", size, one_suffix)
+        format!("{}", size)
     }
-}
-
-fn get_id(size: usize) -> String {
-    get_id_with_suffixes(size, " B", " KiB", " MiB", " GiB")
-}
-
-fn fill(cache: &mut LruCache<u64, String>, rng: &mut impl Rng) -> Vec<u64> {
-    let mut added = 0;
-    let old_len = cache.len();
-
-    while old_len + added == cache.len() {
-        let key = rng.gen();
-        let value = value();
-        cache.insert(key, value).unwrap();
-        added += 1;
-    }
-
-    cache.keys().cloned().collect()
-}
-
-/// Generates a new LRU cache and also returns its keys as a vector.
-fn prepare_benchmark(size: usize)
-        -> (String, LruCache<u64, String>, Vec<u64>, ThreadRng) {
-    let id = get_id(size);
-    let mut rng = rand::thread_rng();
-    let mut cache = LruCache::new(size);
-    let keys = fill(&mut cache, &mut rng);
-    (id, cache, keys, rng)
-}
-
-fn bench_cache_function<F>(group: &mut BenchmarkGroup<WallTime>,
-    size: usize, run_benchmark: F)
-where
-    F: Fn(&mut LruCache<u64, String>, &[u64], &mut ThreadRng)
-{
-    let (id, mut cache, keys, mut rng) = prepare_benchmark(size);
-
-    group.bench_function(id, |b| b.iter(||
-        run_benchmark(&mut cache, &keys, &mut rng)));
-}
-
-fn bench_cache_function_with_refill<F>(group: &mut BenchmarkGroup<WallTime>,
-    size: usize, run_benchmark: F)
-where
-    F: Fn(&mut LruCache<u64, String>, &[u64], &mut ThreadRng)
-{
-    let (id, mut cache, mut keys, mut rng) = prepare_benchmark(size);
-
-    // TODO find a solution that does not measure the "fill" function as well.
-
-    group.bench_function(id, |b| b.iter(
-        || {
-            run_benchmark(&mut cache, &keys, &mut rng);
-            keys = fill(&mut cache, &mut rng);
-        }));
 }
 
 const LINEAR_TIME_SIZES: &'static [usize] = &[
-    4 * 1024,
-    64 * 1024,
-    1024 * 1024,
-    16 * 1024 * 1024
+    64,
+    1024,
+    16 * 1024,
+    256 * 1024
 ];
 
 const CONSTANT_TIME_SIZES: &'static [usize] = &[
-    64 * 1024,
-    1024 * 1024,
-    16 * 1024 * 1024,
-    256 * 1024 * 1024
+    1024,
+    16 * 1024,
+    256 * 1024,
+    4 * 1024 * 1024
 ];
 
 const BENCH_DURATION: Duration = Duration::from_secs(15);
@@ -127,6 +57,7 @@ criterion::criterion_group!(benches,
     iter::iter_benchmark,
     peek::peek_benchmark,
     remove::remove_benchmark,
-    retain::retain_benchmark
+    retain::retain_benchmark,
 );
+
 criterion::criterion_main!(benches);

--- a/benches/bench/peek.rs
+++ b/benches/bench/peek.rs
@@ -1,23 +1,19 @@
 use criterion::Criterion;
-
-use lru_mem::LruCache;
-
 use rand::Rng;
-use rand::rngs::ThreadRng;
 
-fn run_peek_benchmark(cache: &mut LruCache<u64, String>, keys: &[u64],
-        _: &mut ThreadRng) {
-    let mut rng = rand::thread_rng();
-    let get_index = rng.gen_range(0..keys.len());
-    cache.peek(&keys[get_index]);
-}
+use crate::bencher_extensions::CacheBenchmarkGroup;
 
 pub(crate) fn peek_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("peek");
     group.sample_size(100).measurement_time(crate::BENCH_DURATION);
+    let mut rng = rand::thread_rng();
 
     for &size in crate::CONSTANT_TIME_SIZES {
-        crate::bench_cache_function(
-            &mut group, size, run_peek_benchmark);
+        let id = crate::get_id(size);
+
+        group.bench_with_cache(&id, |cache, keys| {
+            let key_index = rng.gen_range(0..keys.len());
+            cache.peek(&keys[key_index]);
+        }, size);
     }
 }

--- a/benches/bench/retain.rs
+++ b/benches/bench/retain.rs
@@ -1,20 +1,15 @@
 use criterion::Criterion;
-
 use lru_mem::LruCache;
 
-use rand::rngs::ThreadRng;
-
-fn run_retain_benchmark(cache: &mut LruCache<u64, String>, _: &[u64],
-        _: &mut ThreadRng) {
-    cache.retain(|k, v| (*k + v.len() as u64) % 2 == 0);
-}
+use crate::bencher_extensions::CacheBenchmarkGroup;
 
 pub(crate) fn retain_benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("retain");
     group.sample_size(100).measurement_time(crate::BENCH_DURATION);
 
     for &size in crate::LINEAR_TIME_SIZES {
-        crate::bench_cache_function_with_refill(
-            &mut group, size, run_retain_benchmark);
+        group.bench_with_reset_cache(&crate::get_id(size), |cache| {
+            cache.retain(|key, _| key.chars().last().unwrap() != '7');
+        }, LruCache::clear, size);
     }
 }


### PR DESCRIPTION
Also use String keys to make hash lookups more realistic